### PR TITLE
Changed Batch & Delete operation return types

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,9 +27,15 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-    
+
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+
+    <!-- Disable automagic references for F# DotNet SDK -->
+    <!-- This will not do anything for other project types -->
+    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -130,7 +136,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -163,7 +169,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-    
+
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/paket.lock
+++ b/paket.lock
@@ -2,9 +2,9 @@ STORAGE: NONE
 RESTRICTION: || (== netcoreapp3.1) (== netstandard2.0) (== netstandard2.1)
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    AWSSDK.Core (3.3.106.17)
-    AWSSDK.DynamoDBv2 (3.3.105.39)
-      AWSSDK.Core (>= 3.3.106.17 < 3.4)
+    AWSSDK.Core (3.3.106.18)
+    AWSSDK.DynamoDBv2 (3.3.105.40)
+      AWSSDK.Core (>= 3.3.106.18 < 3.4)
     Expecto (9.0)
       FSharp.Core (>= 4.6)
       Mono.Cecil (>= 0.11.2)
@@ -179,7 +179,7 @@ NUGET
       System.Security.AccessControl (>= 4.7)
       System.Security.Principal.Windows (>= 4.7)
     Mono.Posix.NETStandard (1.0)
-    MSBuild.StructuredLogger (2.1.117)
+    MSBuild.StructuredLogger (2.1.133)
       Microsoft.Build (>= 16.4)
       Microsoft.Build.Framework (>= 16.4)
       Microsoft.Build.Tasks.Core (>= 16.4)

--- a/src/FSharp.AWS.DynamoDB/RecordTemplate.fs
+++ b/src/FSharp.AWS.DynamoDB/RecordTemplate.fs
@@ -56,9 +56,16 @@ type RecordTemplate<'TRecord> internal () =
     /// <summary>
     ///     Extracts the key that corresponds to supplied record instance.
     /// </summary>
-    /// <param name="item">Input record instance.</param>
+    /// <param name="record">Input record instance.</param>
     member __.ExtractKey(record : 'TRecord) =
         PrimaryKeyStructure.ExtractKey(recordInfo.PrimaryKeyStructure, record)
+
+    /// <summary>
+    ///     Extracts the key that corresponds to supplied record instance.
+    /// </summary>
+    /// <param name="attributeValues">Key attribute values</param>
+    member __.ExtractKey(attributeValues : Dictionary<string, AttributeValue>) =
+        PrimaryKeyStructure.ExtractKey(recordInfo.PrimaryKeyStructure, attributeValues)
 
     /// Generates a conditional which verifies whether an item already exists.
     member __.ItemExists =

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -507,7 +507,7 @@ type TableContext<'TRecord> internal (client : IAmazonDynamoDB, tableName : stri
     /// <summary>
     ///     Asynchronously deletes item of given key from table.
     /// </summary>
-    /// <returns>The deleted item, or None if nothing was deleted</returns>
+    /// <returns>The deleted item, or None if the item didn’t exist.</returns>
     /// <param name="key">Key of item to be deleted.</param>
     /// <param name="precondition">Specifies a precondition expression that existing item should satisfy.</param>
     member __.DeleteItemAsync(key : TableKey, ?precondition : ConditionExpression<'TRecord>) : Async<'TRecord option> = async {
@@ -534,7 +534,7 @@ type TableContext<'TRecord> internal (client : IAmazonDynamoDB, tableName : stri
     /// <summary>
     ///     Asynchronously deletes item of given key from table.
     /// </summary>
-    /// <returns>The deleted item, or None if nothing was deleted</returns>
+    /// <returns>The deleted item, or None if the item didn’t exist.</returns>
     /// <param name="key">Key of item to be deleted.</param>
     /// <param name="precondition">Specifies a precondition expression that existing item should satisfy.</param>
     member __.DeleteItemAsync(key : TableKey, precondition : Expr<'TRecord -> bool>) : Async<'TRecord option> = async {

--- a/tests/FSharp.AWS.DynamoDB.Tests/Program.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Program.fs
@@ -57,7 +57,9 @@ let SimpleTableOperationTests =
             testCase "Simple Put Operation" simpleTableOperationTests.``Simple Put Operation``
             testCase "ContainsKey Operation" simpleTableOperationTests.``ContainsKey Operation``
             testCase "Batch Put Operation" simpleTableOperationTests.``Batch Put Operation``
+            testCase "Batch Delete Operation" simpleTableOperationTests.``Batch Delete Operation``
             testCase "Simple Delete Operation" simpleTableOperationTests.``Simple Delete Operation``
+            testCase "Idempotent Delete Operation" simpleTableOperationTests.``Idempotent Delete Operation``
         ]
 
 let conditionalExpressionTestsTableFixture = new TableFixture()

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -47,11 +47,11 @@ module SimpleTableTypes =
 type ``Simple Table Operation Tests`` (fixture : TableFixture) =
 
     let rand = let r = Random() in fun () -> int64 <| r.Next()
-    let mkItem() = 
-        { 
-            HashKey = guid() ; RangeKey = guid() ; 
+    let mkItem() =
+        {
+            HashKey = guid() ; RangeKey = guid() ;
             Value = rand() ; Tuple = rand(), rand() ;
-            Map = seq { for i in 0L .. rand() % 5L -> "K" + guid(), rand() } |> Map.ofSeq 
+            Map = seq { for i in 0L .. rand() % 5L -> "K" + guid(), rand() } |> Map.ofSeq
             Unions = [Choice1Of3 (guid()) ; Choice2Of3(rand()) ; Choice3Of3(Guid.NewGuid().ToByteArray())]
         }
 
@@ -59,11 +59,11 @@ type ``Simple Table Operation Tests`` (fixture : TableFixture) =
 
     member this.``Convert to compatible table`` () =
         let table' = table.WithRecordType<CompatibleRecord> ()
-        Expect.equal table'.PrimaryKey table.PrimaryKey "PrimaryKey should be equal" 
+        Expect.equal table'.PrimaryKey table.PrimaryKey "PrimaryKey should be equal"
 
     member this.``Convert to compatible table 2`` () =
         let table' = table.WithRecordType<CompatibleRecord2> ()
-        Expect.equal table'.PrimaryKey table.PrimaryKey "PrimaryKey should be equal" 
+        Expect.equal table'.PrimaryKey table.PrimaryKey "PrimaryKey should be equal"
 
     member this.``Simple Put Operation`` () =
         let value = mkItem()
@@ -80,14 +80,34 @@ type ``Simple Table Operation Tests`` (fixture : TableFixture) =
 
     member this.``Batch Put Operation`` () =
         let values = set [ for i in 1L .. 20L -> mkItem() ]
-        let keys = table.BatchPutItems values
-        let values' = table.BatchGetItems keys |> Set.ofArray
+        let unprocessed = table.BatchPutItems values
+        let values' = table.BatchGetItems (values |> Seq.map (fun r -> TableKey.Combined (r.HashKey, r.RangeKey))) |> Set.ofArray
+        Expect.isEmpty unprocessed "Batch Put operations should have all succeeded"
         Expect.equal values' values "values should be equal"
+
+    member this.``Batch Delete Operation`` () =
+        let values = set [ for i in 1L .. 20L -> mkItem() ]
+        table.BatchPutItems values |> ignore
+        let unprocessed = table.BatchDeleteItems (values |> Seq.map (fun r -> TableKey.Combined (r.HashKey, r.RangeKey)))
+        Expect.isEmpty unprocessed "Batch Delete operations should have all succeeded"
+        let values' = table.BatchGetItems (values |> Seq.map (fun r -> TableKey.Combined (r.HashKey, r.RangeKey))) |> Set.ofArray
+        Expect.isEmpty values' "values should be empty"
 
     member this.``Simple Delete Operation`` () =
         let item = mkItem()
         let key = table.PutItem item
         Expect.equal (table.ContainsKey key) true "ContainsKey should be true"
         let item' = table.DeleteItem key
-        Expect.equal item' item "item should be equal"
+        Expect.isSome item' "deleted item should be returned"
+        Expect.equal item' (Some item) "item should be equal"
         Expect.equal (table.ContainsKey key) false "ContainsKey should be false"
+
+    member this.``Idempotent Delete Operation`` () =
+        let item = mkItem()
+        let key = table.PutItem item
+        Expect.equal (table.ContainsKey key) true "ContainsKey should be true"
+        let item' = table.DeleteItem key
+        Expect.isSome item' "deleted item should be returned"
+        let deletedItem = table.DeleteItem key
+        Expect.isNone deletedItem "delete nonexistent item should return None"
+        Expect.isFalse (table.ContainsKey key) "ContainsKey should be false"


### PR DESCRIPTION
**BREAKING CHANGES**

* `BatchPutItems` & `BatchDeleteItems` now return unprocessed items/keys (previously they returned 'written records' and unit respectively)

In DynamoDB throttling conditions the batch may partially succeed and the call will return the unprocessed put/delete operations. The previous API was not exposing this, BatchPutItems in particular would return all records even if some failed.

Under the new model, the unprocessed records/keys returned can be applied directly to another batch call - this is more in line with the intent of the Dynamo API

Implements #17 

* `DeleteItem` now returns `Option`

Previously if `DeleteItem` was called with a non-existent key the call would return an 'empty' record or throw a pickler exception. This has been changed to return None - the Dynamo DeleteItem API is intended to be idempotent.

Implements #15 
