### PR TITLE
Removed regex validation on attribute names

### DIFF
--- a/src/FSharp.AWS.DynamoDB/Picklers/PropertyMetadata.fs
+++ b/src/FSharp.AWS.DynamoDB/Picklers/PropertyMetadata.fs
@@ -8,7 +8,7 @@ open System.Reflection
 //  Pickler metadata for F# type properties
 //
 
-[<CustomEquality; NoComparison>] 
+[<CustomEquality; NoComparison>]
 type PropertyMetadata =
     {
         Name : string
@@ -30,10 +30,10 @@ with
 
     static member FromPropertyInfo (resolver : IPicklerResolver) (attrId : int) (prop : PropertyInfo) =
         let attributes = prop.GetAttributes()
-        let pickler = 
+        let pickler =
             match attributes |> Seq.tryPick (fun a -> match box a with :? IPropertySerializer as ps -> Some ps | _ -> None) with
             | Some serializer -> mkSerializerAttributePickler resolver serializer prop.PropertyType
-            | None when attributes |> containsAttribute<StringRepresentationAttribute> -> 
+            | None when attributes |> containsAttribute<StringRepresentationAttribute> ->
                 mkStringRepresentationPickler resolver prop
             | None -> resolver.Resolve prop.PropertyType
 
@@ -43,7 +43,7 @@ with
             | None -> prop.Name
 
         if not <| isValidFieldName name then
-            invalidArg name "invalid record field name; must be alphanumeric and should not begin with a number."
+            invalidArg name "invalid record field name; must be 1 to 64k long (as utf8)."
 
         {
             Name = name

--- a/src/FSharp.AWS.DynamoDB/RecordKeySchema.fs
+++ b/src/FSharp.AWS.DynamoDB/RecordKeySchema.fs
@@ -53,6 +53,7 @@ type RecordTableInfo =
     }
 
 
+
 type PrimaryKeyStructure with
     /// Extracts given TableKey to AttributeValue form
     static member ExtractKey(keyStructure : PrimaryKeyStructure, key : TableKey) =
@@ -197,8 +198,8 @@ type RecordTableInfo with
                     |> invalidArg (string typeof<'T>)
 
                 | Some hkca, None, [|(KeyType.Range, rk)|] ->
-                    if not <| isValidFieldName hkca.Name then
-                        invalidArg hkca.Name "invalid hashkey name; must be alphanumeric and should not begin with a number."
+                    if not <| isValidKeyName hkca.Name then
+                        invalidArg hkca.Name "invalid hashkey name; must be 1 to 255 bytes long (as utf8)."
 
                     if pickler.Properties |> Array.exists(fun p -> p.Name = hkca.Name) then
                         invalidArg (string typeof<'T>) "Default HashKey attribute contains conflicting name."
@@ -207,8 +208,8 @@ type RecordTableInfo with
                     DefaultHashKey(hkca.Name, hkca.HashKey, pickler, rk) |> setResult
 
                 | None, Some rkca, [|(KeyType.Hash, hk)|] ->
-                    if not <| isValidFieldName rkca.Name then
-                        invalidArg rkca.Name "invalid rangekey name; must be alphanumeric and should not begin with a number."
+                    if not <| isValidKeyName rkca.Name then
+                        invalidArg rkca.Name "invalid rangekey name; must be 1 to 255 bytes long (as utf8)."
 
                     if pickler.Properties |> Array.exists(fun p -> p.Name = rkca.Name) then
                         invalidArg (string typeof<'T>) "Default RangeKey attribute contains conflicting name."

--- a/src/FSharp.AWS.DynamoDB/Utils/DynamoUtils.fs
+++ b/src/FSharp.AWS.DynamoDB/Utils/DynamoUtils.fs
@@ -121,9 +121,14 @@ let isValidTableName (tableName : string) =
     elif not <| tableNameRegex.IsMatch tableName then false
     else true
 
-let private fieldNameRegex = new Regex("^[a-zA-Z][a-zA-Z0-9]*", RegexOptions.Compiled)
+let private utf8Length (str : string) =
+    System.Text.Encoding.UTF8.GetBytes(str).Length
+
 let isValidFieldName (name : string) =
-    name <> null && fieldNameRegex.IsMatch name
+    name <> null && name.Length > 0 && utf8Length name <= 65535
+
+let isValidKeyName (name : string) =
+    name <> null && name.Length > 0 && utf8Length name <= 255
 
 let unprocessedDeleteAttributeValues tableName (response : BatchWriteItemResponse) =
     let (ok, reqs) = response.UnprocessedItems.TryGetValue tableName

--- a/tests/FSharp.AWS.DynamoDB.Tests/RecordGenerationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/RecordGenerationTests.fs
@@ -13,7 +13,7 @@ module ``Record Generation Tests`` =
 
     type Test private () =
         static let config =
-            { Config.QuickThrowOnFailure with 
+            { Config.QuickThrowOnFailure with
                 Arbitrary = [ typeof<FsCheckGenerators> ] }
 
         static member RoundTrip<'Record when 'Record : equality> (?tolerateInequality) =
@@ -26,18 +26,18 @@ module ``Record Generation Tests`` =
                     if tolerateInequality then
                         if not !isFoundInequality && r <> r' then
                             isFoundInequality := true
-                            sprintf "Error when equality testing %O:\nExpected: %A\nActual: %A" 
+                            sprintf "Error when equality testing %O:\nExpected: %A\nActual: %A"
                                 typeof<'Record> r r'
                             |> Console.WriteLine
                     else
                         Expect.equal r' r "Record should be equal"
-                with 
+                with
                 // account for random inputs not supported by the library
-                | :? System.InvalidOperationException as e 
+                | :? System.InvalidOperationException as e
                     when e.Message = "empty strings not supported by DynamoDB." -> ()
                 | :? System.ArgumentException as e
-                    when e.Message.Contains "unsupported key name" && 
-                         e.Message.Contains "should be alphanumeric and not starting with digit" -> ()
+                    when e.Message.Contains "unsupported key name" &&
+                         e.Message.Contains "should be 1 to 64k long (as utf8)" -> ()
 
             Check.One(config, roundTrip)
 
@@ -58,8 +58,8 @@ module ``Record Generation Tests`` =
     [<ConstantRangeKeyAttribute("RangeKey", "Constant")>]
     type ``BS Constant RangeKey Record`` = { [<HashKey>] A1 : byte[] }
 
-    type ``SS String Representation Record`` = 
-        { 
+    type ``SS String Representation Record`` =
+        {
             [<HashKey; StringRepresentation>]  A1 : byte[]
             [<RangeKey; StringRepresentation>] B1 : int64
         }
@@ -141,8 +141,8 @@ module ``Record Generation Tests`` =
 
     type NestedUnion = UA of int | UB of string | UC of byte[] * DateTimeOffset
 
-    type ``Complex Record A`` = 
-        { 
+    type ``Complex Record A`` =
+        {
             [<HashKey>]HashKey : string
             [<RangeKey>]RangeKey : string
 
@@ -165,8 +165,8 @@ module ``Record Generation Tests`` =
         }
 
 
-    type ``Complex Record B`` = 
-        { 
+    type ``Complex Record B`` =
+        {
             [<HashKey>]HashKey : byte[]
             [<RangeKey>]RangeKey : decimal
 
@@ -177,8 +177,8 @@ module ``Record Generation Tests`` =
             BlobValue : (int * string) [][]
         }
 
-    type ``Complex Record C`` = 
-        { 
+    type ``Complex Record C`` =
+        {
             [<HashKey>]HashKey : decimal
             [<RangeKey>]RangeKey : byte
 
@@ -275,7 +275,7 @@ module ``Record Generation Tests`` =
         |> shouldFailwith<_, ArgumentException>
 
     [<ConstantHashKeyAttribute("HashKey", "HashKeyValue")>]
-    type ``Record containing costant HashKey attribute with HashKey attribute`` = 
+    type ``Record containing costant HashKey attribute with HashKey attribute`` =
         { [<HashKey>]HashKey : string ; [<RangeKey>]RangeKey : string }
 
     let ``Record containing costant HashKey attribute with HashKey attribute should fail`` () =
@@ -286,7 +286,7 @@ module ``Record Generation Tests`` =
     type FooRecord = { A : int ; B : string ; C : DateTimeOffset * string }
 
     let ``Generated picklers should be singletons`` () =
-        Expect.equal 
+        Expect.equal
             (Array.Parallel.init 100 (fun _ -> Pickler.resolve<FooRecord>())
              |> Seq.distinct
              |> Seq.length)
@@ -367,7 +367,7 @@ module ``Record Generation Tests`` =
 
     let ``GSI should fail if invalid key type`` () =
         fun () -> RecordTemplate.Define<GSI4>()
-        |> shouldFailwith<_, ArgumentException>        
+        |> shouldFailwith<_, ArgumentException>
 
     let ``Sparse GSI`` () =
         let template = RecordTemplate.Define<GSI5>()
@@ -378,8 +378,8 @@ module ``Record Generation Tests`` =
 
     let ``GSI should fail with option primary hash key`` () =
         fun () -> RecordTemplate.Define<GSI6>()
-        |> shouldFailwith<_, ArgumentException>  
-        
+        |> shouldFailwith<_, ArgumentException>
+
     type LSI1 =
         {
             [<HashKey>]
@@ -435,8 +435,8 @@ module ``Record Generation Tests`` =
     let ``DateTimeOffset pickler encoding should preserve offsets`` () =
         let config = { Config.QuickThrowOnFailure with MaxTest = 1000 }
         let pickler = new DateTimeOffsetPickler()
-        Check.One(config, 
-            fun (d:DateTimeOffset) -> 
-                let d' = pickler.UnParse d |> pickler.Parse 
+        Check.One(config,
+            fun (d:DateTimeOffset) ->
+                let d' = pickler.UnParse d |> pickler.Parse
                 Expect.equal d'.DateTime d.DateTime "Date should be equal"
                 d'.Offset |> Expect.equal d.Offset)


### PR DESCRIPTION
There don't appear to be any AWS limits on the characters used in Dynamo attribute names, so I’ve removed the regex. Unsure if there was another reason this was there.

I’ve added length validation (> 1 character, < 64k for attributes, < 255 characters for key attributes) assessed against the utf8-encoded length of the name.