### PR TITLE
Minor tidying

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,6 @@ indent_size = 2
 
 # fsharp files
 [*.{fs, fsx}]
-indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/FSharp.AWS.DynamoDB.sln
+++ b/FSharp.AWS.DynamoDB.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{BF60
 		License.md = License.md
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A157294B-F680-4AA4-910C-BC63840FF6E3}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.com/fsprojects/FSharp.AWS.DynamoDB/workflows/Build/badge.svg) [![NuGet Badge](https://buildstats.info/nuget/FSharp.AWS.DynamoDB?includePreReleases=true)](https://www.nuget.org/packages/FSharp.AWS.DynamoDB)
 
-FSharp.AWS.DynamoDB an F# wrapper over the standard Amazon.DynamoDB library which
+`FSharp.AWS.DynamoDB` an F# wrapper over the standard `AWSSDK.DynamoDBv2` library which
 allows you to represent table items using F# records and perform updates, queries and scans
 using F# quotation expressions.
 
@@ -29,7 +29,7 @@ type WorkItemInfo =
 		Started : DateTimeOffset option
 	}
 ```
-We can now perfom table operations on DynamoDB like so
+We can now perform table operations on DynamoDB like so
 ```fsharp
 open Amazon.DynamoDBv2
 
@@ -67,17 +67,17 @@ let updated = table.UpdateItem <@ fun r -> SET r.Name "newName" &&& ADD r.Depend
 
 ## Supported Field Types
 
-FSharp.AWS.DynamoDB supports the following field types:
+`FSharp.AWS.DynamoDB` supports the following field types:
 * Numerical types, enumerations and strings.
 * Array, Nullable, Guid, DateTimeOffset and TimeSpan.
 * F# lists
 * F# sets with elements of type number, string or `byte[]`.
 * F# maps with key of type string.
-* F# records and unions (recursive types not supported).
+* F# records and unions (recursive types not supported, nested ones are).
 
-## Supported methods in Query Expressions
+## Supported operators in Query Expressions
 
-Query expressions support the following F# methods in their predicates:
+Query expressions support the following F# operators in their predicates:
 * `Array.length`, `List.length`, `Set.count` and `Map.Count`.
 * `String.StartsWith` and `String.Contains`.
 * `Set.contains` and `Map.containsKey`.
@@ -85,7 +85,7 @@ Query expressions support the following F# methods in their predicates:
 * `Option.isSome`, `Option.isNone`, `Option.Value` and `Option.get`.
 * `fst` and `snd` for tuple records.
 
-## Supported methods in Update Expressions
+## Supported operators in Update Expressions
 
 Update expressions support the following F# value constructors:
 * `(+)` and `(-)` in numerical and set types.
@@ -100,11 +100,11 @@ Update expressions support the following F# value constructors:
 ## Example: Creating an atomic counter
 
 ```fsharp
-type private CounterEntry = { [<HashKey>]Id : Guid ; Value : int64 }
+type private CounterEntry = { [<HashKey>] Id : Guid ; Value : int64 }
 
 type Counter private (table : TableContext<CounterEntry>, key : TableKey) =
-    member __.Value = table.GetItem(key).Value
-    member __.Incr() = 
+    member _.Value = table.GetItem(key).Value
+    member _.Incr() = 
         let updated = table.UpdateItem(key, <@ fun e -> { e with Value = e.Value + 1L } @>)
         updated.Value
 
@@ -132,8 +132,8 @@ type Record =
     {
         [<HashKey>] HashKey : string
         ...
-        [<GlobalSecondaryHashKey(indexName = "Index")>]GSIH : string
-        [<GlobalSecondaryRangeKey(indexName = "Index")>]GSIR : string
+        [<GlobalSecondaryHashKey(indexName = "Index")>] GSIH : string
+        [<GlobalSecondaryRangeKey(indexName = "Index")>] GSIR : string
     }
 ```
 Queries can now be performed on the `GSIH` and `GSIR` fields as if they were regular hashkey and rangekey attributes.
@@ -151,7 +151,7 @@ type Record =
 ```
 Queries can now be performed using LSI as a secondary RangeKey.
 
-NB: Due to API restrictions, secondary indices in the scope of FSharp.AWS.DynamoDB always project *all* table attributes
+NB: Due to API restrictions, secondary indices in the scope of `FSharp.AWS.DynamoDB` always project *all* table attributes,
 which can incur additional costs from Amazon.
 
 ### Pagination
@@ -238,7 +238,7 @@ Tests are run using dynamodb-local on port 8000. Using the docker image is recom
 
 then
 
-`dotnet run -p tests/FSharp.AWS.DynamoDB.Tests/FSharp.AWS.DynamoDB.Tests.fsproj`
+`dotnet run --project tests/FSharp.AWS.DynamoDB.Tests/FSharp.AWS.DynamoDB.Tests.fsproj`
 
 ## Maintainer(s)
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.401"
+    "version": "5.0.401",
+    "rollForward": "latestMajor"
   }
 }

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -1,7 +1,11 @@
-﻿#I "../../bin"
+﻿#if USE_PUBLISHED_NUGET // If you don't want to do a local build first
+#r "nuget: FSharp.AWS.DynamoDB, *-*" // *-* to white-list the fact that all releases to date have been `-beta` sufficed
+#else
+#I "../../bin/net5.0/"
 #r "AWSSDK.Core.dll"
 #r "AWSSDK.DynamoDBv2.dll"
 #r "FSharp.AWS.DynamoDB.dll"
+#endif
 
 open System
 

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -9,15 +9,21 @@
 
 open System
 
-open Amazon
-open Amazon.Util
 open Amazon.DynamoDBv2
-open Amazon.DynamoDBv2.Model
 
 open FSharp.AWS.DynamoDB
 
+#if USE_CLOUD
+open Amazon
+open Amazon.Util
 let account = AWSCredentialsProfile.LoadFrom("default").Credentials
 let ddb = new AmazonDynamoDBClient(account, RegionEndpoint.EUCentral1) :> IAmazonDynamoDB
+#else // Use Docker-hosted dynamodb-local instance
+let clientConfig = AmazonDynamoDBConfig(ServiceURL = "http://localhost:8000")
+// Credenitals are not validated if connecting to local instance so anything will do (this avoids it looking for profiles to be configured)
+let credentials = Amazon.Runtime.BasicAWSCredentials("A", "A") // or Amazon.Runtime.AWSCredentials.FromEnvironmentVariables()
+let ddb = new AmazonDynamoDBClient(credentials, clientConfig) :> IAmazonDynamoDB
+#endif
 
 type Nested = { A : string ; B : System.Reflection.BindingFlags }
 

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -19,9 +19,14 @@ open Amazon.Util
 let account = AWSCredentialsProfile.LoadFrom("default").Credentials
 let ddb = new AmazonDynamoDBClient(account, RegionEndpoint.EUCentral1) :> IAmazonDynamoDB
 #else // Use Docker-hosted dynamodb-local instance
+// See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#docker for details of how to deploy a simulator instance
 let clientConfig = AmazonDynamoDBConfig(ServiceURL = "http://localhost:8000")
-// Credenitals are not validated if connecting to local instance so anything will do (this avoids it looking for profiles to be configured)
-let credentials = Amazon.Runtime.BasicAWSCredentials("A", "A") // or Amazon.Runtime.AWSCredentials.FromEnvironmentVariables()
+#if USE_CREDS_FROM_ENV_VARS // 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY' must be set for this to work
+let credentials = AWSCredentials.FromEnvironmentVariables()
+#else
+// Credentials are not validated if connecting to local instance so anything will do (this avoids it looking for profiles to be configured)
+let credentials = Amazon.Runtime.BasicAWSCredentials("A", "A")
+#endif
 let ddb = new AmazonDynamoDBClient(credentials, clientConfig) :> IAmazonDynamoDB
 #endif
 

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -1319,7 +1319,7 @@ type TableContext =
     static member CreateAsync<'TRecord>(client : IAmazonDynamoDB, tableName : string, ?verifyTable : bool, ?createIfNotExists : bool,
                                                                     ?provisionedThroughput : ProvisionedThroughput, ?metricsCollector : (RequestMetrics -> unit)) : Async<TableContext<'TRecord>> = async {
 
-        if not <| isValidTableName tableName then invalidArg tableName "unsupported DynamoDB table name."
+        if not <| isValidTableName tableName then invalidArg "tableName" "unsupported DynamoDB table name."
         let verifyTable = defaultArg verifyTable true
         let createIfNotExists = defaultArg createIfNotExists false
         let context = new TableContext<'TRecord>(client, tableName, RecordTemplate.Define<'TRecord>(), metricsCollector)

--- a/src/FSharp.AWS.DynamoDB/Types.fs
+++ b/src/FSharp.AWS.DynamoDB/Types.fs
@@ -49,8 +49,8 @@ type LocalSecondaryIndexAttribute private (indexName : string option) =
 type ConstantHashKeyAttribute(name : string, hashkey : obj) =
     inherit Attribute()
     do
-        if isNull name then raise <| ArgumentNullException("'Name' parameter cannot be null.")
-        if isNull hashkey then raise <| ArgumentNullException("'HashKey' parameter cannot be null.")
+        if isNull name then raise <| ArgumentNullException("name")
+        if isNull hashkey then raise <| ArgumentNullException("hashkey")
 
     member __.Name = name
     member __.HashKey = hashkey
@@ -62,8 +62,8 @@ type ConstantHashKeyAttribute(name : string, hashkey : obj) =
 type ConstantRangeKeyAttribute(name : string, rangeKey : obj) =
     inherit Attribute()
     do
-        if isNull name then raise <| ArgumentNullException("'Name' parameter cannot be null.")
-        if isNull rangeKey then raise <| ArgumentNullException("'HashKey' parameter cannot be null.")
+        if isNull name then raise <| ArgumentNullException("name")
+        if isNull rangeKey then raise <| ArgumentNullException("rangeKey")
 
     member __.Name = name
     member __.RangeKey = rangeKey
@@ -79,7 +79,7 @@ type StringRepresentationAttribute() =
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type CustomNameAttribute(name : string) =
     inherit System.Attribute()
-    do if isNull name then raise <| ArgumentNullException("'Name' parameter cannot be null.")
+    do if isNull name then raise <| ArgumentNullException("name")
     member __.Name = name
 
 /// Specifies that record deserialization should fail if not corresponding attribute
@@ -179,17 +179,17 @@ type TableKey private (hashKey : obj, rangeKey : obj) =
 
     /// Defines a table key using provided HashKey
     static member Hash<'HashKey>(hashKey : 'HashKey) =
-        if isNull hashKey then raise <| ArgumentNullException("HashKey must not be null")
+        if isNull hashKey then raise <| ArgumentNullException("hashKey")
         TableKey(hashKey, null)
 
     /// Defines a table key using provided RangeKey
     static member Range<'RangeKey>(rangeKey : 'RangeKey) =
-        if isNull rangeKey then raise <| ArgumentNullException("RangeKey must not be null")
+        if isNull rangeKey then raise <| ArgumentNullException("rangeKey")
         TableKey(null, rangeKey)
 
     /// Defines a table key using combined HashKey and RangeKey
     static member Combined<'HashKey, 'RangeKey>(hashKey : 'HashKey, rangeKey : 'RangeKey) =
-        if isNull hashKey then raise <| ArgumentNullException("HashKey must not be null")
+        if isNull hashKey then raise <| ArgumentNullException("hashKey")
         TableKey(hashKey, rangeKey)
 
 /// Query (start/last evaluated) key identifier
@@ -216,12 +216,12 @@ type IndexKey private (hashKey : obj, rangeKey : obj, primaryKey: TableKey) =
 
     /// Defines an index key using provided HashKey and primary TableKey
     static member Hash<'HashKey>(hashKey : 'HashKey, primaryKey: TableKey) =
-        if isNull hashKey then raise <| ArgumentNullException("HashKey must not be null")
+        if isNull hashKey then raise <| ArgumentNullException("hashKey") 
         IndexKey(hashKey, null, primaryKey)
 
     /// Defines an index key using combined HashKey, RangeKey and primary TableKey
     static member Combined<'HashKey, 'RangeKey>(hashKey : 'HashKey, rangeKey : 'RangeKey, primaryKey: TableKey) =
-        if isNull hashKey then raise <| ArgumentNullException("HashKey must not be null")
+        if isNull hashKey then raise <| ArgumentNullException("hashKey")
         IndexKey(hashKey, rangeKey, primaryKey)
 
     // Defines an index key using just the primary TableKey


### PR DESCRIPTION
- Allow loading .sln with only .NET >= 6 SDK
- Minor typo fixes
- Minor `ArgumentNullException` corrections
- Add `#r nuget:` ref to `Script.fsx` to enable working without compiling first
- Add `#ifdef`'d section enabling connecting to a DynamoDB simulator on `http://localhost:8000` (e.g. a [docker `amazon/dynamodb-local` image](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#docker))