### PR TITLE
Move Sync-over-Async into Scripting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 0.9.4-beta
+* Moved Sync-over-Async versions of `TableContext` operations into `namespace FSharp.AWS.DynamoDB.Scripting`
+
 ### 0.9.3-beta
 * Added `RequestMetrics` record type
 * Added an optional `metricsCollector` parameter to `TableContext.Create` to receive operation metrics

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -12,6 +12,7 @@ open System
 open Amazon.DynamoDBv2
 
 open FSharp.AWS.DynamoDB
+open FSharp.AWS.DynamoDB.Scripting // non-Async overloads
 
 #if USE_CLOUD
 open Amazon

--- a/tests/FSharp.AWS.DynamoDB.Tests/ConditionalExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/ConditionalExpressionTests.fs
@@ -1,12 +1,11 @@
 ﻿namespace FSharp.AWS.DynamoDB.Tests
 
 open System
-open System.Threading
 
 open Expecto
-open FsCheck
 
 open FSharp.AWS.DynamoDB
+open FSharp.AWS.DynamoDB.Scripting
 
 [<AutoOpen>]
 module CondExprTypes =

--- a/tests/FSharp.AWS.DynamoDB.Tests/PaginationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/PaginationTests.fs
@@ -5,6 +5,7 @@ open System
 open Expecto
 
 open FSharp.AWS.DynamoDB
+open FSharp.AWS.DynamoDB.Scripting
 
 [<AutoOpen>]
 module PaginationTests =

--- a/tests/FSharp.AWS.DynamoDB.Tests/ProjectionExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/ProjectionExpressionTests.fs
@@ -1,13 +1,13 @@
 ﻿namespace FSharp.AWS.DynamoDB.Tests
 
 open System
-open System.Threading
 
 open Microsoft.FSharp.Quotations
 
 open Expecto
 
 open FSharp.AWS.DynamoDB
+open FSharp.AWS.DynamoDB.Scripting
 
 [<AutoOpen>]
 module ProjectionExprTypes =
@@ -78,15 +78,15 @@ type ``Projection Expression Tests`` (fixture : TableFixture) =
     static let rand = let r = Random() in fun () -> int64 <| r.Next()
 
     let bytes() = Guid.NewGuid().ToByteArray()
-    let mkItem() = 
-        { 
+    let mkItem() =
+        {
             HashKey = guid() ; RangeKey = guid() ; String = guid()
             Value = rand() ; Tuple = rand(), rand() ;
             TimeSpan = TimeSpan.FromTicks(rand()) ; DateTimeOffset = DateTimeOffset.Now ; Guid = Guid.NewGuid()
             Bool = false ; Optional = Some (guid()) ; Ref = ref (guid()) ; Bytes = Guid.NewGuid().ToByteArray()
             Nested = { NV = guid() ; NE = enum<Enum> (int (rand()) % 3) } ;
             NestedList = [{ NV = guid() ; NE = enum<Enum> (int (rand()) % 3) } ]
-            Map = seq { for i in 0L .. rand() % 5L -> "K" + guid(), rand() } |> Map.ofSeq 
+            Map = seq { for i in 0L .. rand() % 5L -> "K" + guid(), rand() } |> Map.ofSeq
             IntSet = seq { for i in 0L .. rand() % 5L -> rand() } |> Set.ofSeq
             StringSet = seq { for i in 0L .. rand() % 5L -> guid() } |> Set.ofSeq
             ByteSet = seq { for i in 0L .. rand() % 5L -> bytes() } |> Set.ofSeq
@@ -99,7 +99,7 @@ type ``Projection Expression Tests`` (fixture : TableFixture) =
     let table = TableContext.Create<ProjectionExprRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
 
     member this.``Should fail on invalid projections`` () =
-        let testProj (p : Expr<R -> 'T>) = 
+        let testProj (p : Expr<R -> 'T>) =
             fun () -> proj p
             |> shouldFailwith<_, ArgumentException>
 
@@ -109,7 +109,7 @@ type ``Projection Expression Tests`` (fixture : TableFixture) =
         testProj <@ fun r -> r.List.[0] + 1L @>
 
     member this.``Should fail on conflicting projections`` () =
-        let testProj (p : Expr<R -> 'T>) = 
+        let testProj (p : Expr<R -> 'T>) =
             fun () -> proj p
             |> shouldFailwith<_, ArgumentException>
 

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -1,11 +1,11 @@
 ﻿namespace FSharp.AWS.DynamoDB.Tests
 
 open System
-open System.Threading
 
 open Expecto
 
 open FSharp.AWS.DynamoDB
+open FSharp.AWS.DynamoDB.Scripting // These tests lean on the Synchronous wrappers
 
 [<AutoOpen>]
 module SimpleTableTypes =

--- a/tests/FSharp.AWS.DynamoDB.Tests/SparseGSITests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SparseGSITests.fs
@@ -1,11 +1,11 @@
 ﻿namespace FSharp.AWS.DynamoDB.Tests
 
 open System
-open System.Threading
 
 open Expecto
 
 open FSharp.AWS.DynamoDB
+open FSharp.AWS.DynamoDB.Scripting
 
 [<AutoOpen>]
 module SparseGSITests =
@@ -24,9 +24,9 @@ module SparseGSITests =
 type ``Sparse GSI Tests`` (fixture : TableFixture) =
 
     let rand = let r = Random() in fun () -> int64 <| r.Next()
-    let mkItem() = 
-        { 
-            HashKey = guid() ; RangeKey = guid() ; 
+    let mkItem() =
+        {
+            HashKey = guid() ; RangeKey = guid() ;
             SecondaryHashKey = if rand() % 2L = 0L then Some (guid()) else None ;
         }
 
@@ -42,7 +42,7 @@ type ``Sparse GSI Tests`` (fixture : TableFixture) =
         let value = { mkItem() with SecondaryHashKey = Some(guid()) }
         let key = table.PutItem value
         Expect.equal
-            (table.Query(keyCondition = <@ fun (r: GsiRecord) -> r.SecondaryHashKey = value.SecondaryHashKey @>) 
+            (table.Query(keyCondition = <@ fun (r: GsiRecord) -> r.SecondaryHashKey = value.SecondaryHashKey @>)
              |> Array.length)
             1
             ""
@@ -52,7 +52,7 @@ type ``Sparse GSI Tests`` (fixture : TableFixture) =
         let key = table.PutItem value
         table.UpdateItem(key, <@ fun r -> { r with SecondaryHashKey = None } @>) |> ignore
         Expect.equal
-            (table.Query(keyCondition = <@ fun (r: GsiRecord) -> r.SecondaryHashKey = value.SecondaryHashKey @>) 
+            (table.Query(keyCondition = <@ fun (r: GsiRecord) -> r.SecondaryHashKey = value.SecondaryHashKey @>)
              |> Array.length)
             0
             ""

--- a/tests/FSharp.AWS.DynamoDB.Tests/UpdateExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/UpdateExpressionTests.fs
@@ -1,11 +1,11 @@
 ﻿namespace FSharp.AWS.DynamoDB.Tests
 
 open System
-open System.Threading
 
 open Expecto
 
 open FSharp.AWS.DynamoDB
+open FSharp.AWS.DynamoDB.Scripting
 
 [<AutoOpen>]
 module UpdateExprTypes =


### PR DESCRIPTION
Moved Sync-over-Async delegating wrappers of the fundamentally `Async` operations in `TableContext` into `namespace FSharp.AWS.DynamoDB.Scripting`