### PR TITLE
Add per-Operation collector parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ xunit.html
 .DS_Store
 .ionide/
 .vscode/
+.idea/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ### 0.9.4-beta
 * Moved Sync-over-Async versions of `TableContext` operations into `namespace FSharp.AWS.DynamoDB.Scripting`
+* Added `?collector` parameter to each operation on `TableContext` to enable separated collection for concurrent requests
 
 ### 0.9.3-beta
 * Added `RequestMetrics` record type

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### 0.9.4-beta
 * Moved Sync-over-Async versions of `TableContext` operations into `namespace FSharp.AWS.DynamoDB.Scripting`
 * Added `?collector` parameter to each operation on `TableContext` to enable separated collection for concurrent requests
+* Ensured metrics are reported even for failed requests
 
 ### 0.9.3-beta
 * Added `RequestMetrics` record type


### PR DESCRIPTION
- added a `?collector` param for all operations
- ensured metrics are emitted for exceptional exit cases