### PR TITLE
Clarify ctor/Creation/Verification lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ type Counter private (table : TableContext<CounterEntry>, key : TableKey) =
     static member Create(client : IAmazonDynamoDB, tableName : string) = async {
         let table = TableContext<CounterEntry>(client, tableName)
         let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)        
-        do! table.CreateTableIfNotExistsAsync(Throughput.Provisioned throughput)
+        do! table.VerifyOrCreateTableAsync(Throughput.Provisioned throughput)
         let initialEntry = { Id = Guid.NewGuid() ; Value = 0L }
         let! key = table.PutItemAsync(initialEntry)
         return Counter(table, key)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ let updated = table.UpdateItem(<@ fun r -> { r with Started = Some DateTimeOffse
                                 preCondition = <@ fun r -> r.DateTimeOffset = None @>)
 ```
 
-Or they can be updated using the `UpdateOp` DSL,
+Or they can be updated using [the `SET`, `ADD`, `REMOVE` and `DELETE` operations of the UpdateOp` DSL](./src/FSharp.AWS.DynamoDB/Types.fs#263),
 which is closer to the underlying DynamoDB API:
 
 ```fsharp
@@ -125,7 +125,7 @@ Projection expressions can be used to fetch a subset of table attributes, which 
 table.QueryProjected(<@ fun r -> r.HashKey = "Foo" @>, <@ fun r -> r.HashKey, r.Values.Nested.[0] @>)
 ```
 
-which returns a tuple of the specified attributes. Tuples can be of any arity and must contain non-conflicting document paths.
+the resulting value is a tuple of the specified attributes. Tuples can be of any arity but must contain non-conflicting document paths.
 
 ## Secondary Indices
 
@@ -141,7 +141,8 @@ type Record =
 ```
 
 Queries can now be performed on the `GSIH` and `GSIR` fields as if they were regular hashkey and rangekey attributes.
-Global secondary indices are created using the same provisioned throughput as the primary keys.
+
+_NOTE: Global secondary indices are created using the same provisioned throughput as for the primary keys_.
 
 [Local Secondary Indices](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html) can be defined using the `LocalSecondaryIndex` attribute:
 ```fsharp
@@ -212,13 +213,13 @@ It is possible to precompute a DynamoDB expression as follows:
 let precomputedConditional = table.Template.PrecomputeConditionalExpr <@ fun w -> w.Name <> "test" && w.Dependencies.Contains "mscorlib" @>
 ```
 
-This precomputed conditional can now be used in place of the original expression in the FSharp.AWS.DynamoDB API:
+This precomputed conditional can now be used in place of the original expression in the `FSharp.AWS.DynamoDB` API:
 
 ```fsharp
 let results = table.Scan precomputedConditional
 ```
 
-FSharp.AWS.DynamoDB also supports precomputation of parametric expressions:
+`FSharp.AWS.DynamoDB` also supports precomputation of parametric expressions:
 
 ```fsharp
 let startedBefore = table.Template.PrecomputeConditionalExpr <@ fun time w -> w.StartTime.Value <= time @>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ open FSharp.AWS.DynamoDB.Scripting // Expose non-Async methods, e.g. PutItem/Get
 
 let client : IAmazonDynamoDB = ``your DynamoDB client instance``
 let throughput = ProvisionedThroughput(readCapacityUnits = 1L, writeCapacityUnits = 10L)
-let table = TableContext.Initialize<WorkItemInfo>(client, tableName = "workItems", Provisioned throughput)
+let table = TableContext.Initialize<WorkItemInfo>(client, tableName = "workItems", Throughput.Provisioned throughput)
 
 let workItem = { ProcessId = 0L ; WorkItemId = 1L ; Name = "Test" ; UUID = guid() ; Dependencies = set ["mscorlib"] ; Started = None }
 
@@ -121,7 +121,7 @@ type Counter private (table : TableContext<CounterEntry>, key : TableKey) =
     static member Create(client : IAmazonDynamoDB, tableName : string) = async {
         let table = TableContext<CounterEntry>(client, tableName)
         let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)        
-        do! table.InitializeTableAsync(Provisioned throughput)
+        do! table.InitializeTableAsync(Throughput.Provisioned throughput)
         let initialEntry = { Id = Guid.NewGuid() ; Value = 0L }
         let! key = table.PutItemAsync(initialEntry)
         return Counter(table, key)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ open Amazon.DynamoDBv2
 open FSharp.AWS.DynamoDB.Scripting // Expose non-Async methods, e.g. PutItem/GetItem
 
 let client : IAmazonDynamoDB = ``your DynamoDB client instance``
-let throughput = ProvisionedThroughput(readCapacityUnits = 1L, writeCapacityUnits = 10L)
-let table = TableContext.Initialize<WorkItemInfo>(client, tableName = "workItems", Throughput.Provisioned throughput)
+let table = TableContext.Initialize<WorkItemInfo>(client, tableName = "workItems", Throughput.OnDemand)
 
 let workItem = { ProcessId = 0L ; WorkItemId = 1L ; Name = "Test" ; UUID = guid() ; Dependencies = set ["mscorlib"] ; Started = None }
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ open Amazon.DynamoDBv2
 open FSharp.AWS.DynamoDB.Scripting // Expose non-Async methods, e.g. PutItem/GetItem
 
 let client : IAmazonDynamoDB = ``your DynamoDB client instance``
-let throughput = ProvisionedThroughput (readCapacityUnits = 1L, writeCapacityUnits = 10L)
-let table = TableContext.Initialize<WorkItemInfo>(client, tableName = "workItems", throughput)
+let throughput = ProvisionedThroughput(readCapacityUnits = 1L, writeCapacityUnits = 10L)
+let table = TableContext.Initialize<WorkItemInfo>(client, tableName = "workItems", Provisioned throughput)
 
 let workItem = { ProcessId = 0L ; WorkItemId = 1L ; Name = "Test" ; UUID = guid() ; Dependencies = set ["mscorlib"] ; Started = None }
 
@@ -120,8 +120,8 @@ type Counter private (table : TableContext<CounterEntry>, key : TableKey) =
 
     static member Create(client : IAmazonDynamoDB, tableName : string) = async {
         let table = TableContext<CounterEntry>(client, tableName)
-        let throughput = ProvisionedThroughput(readCapacityUnits = 100L, writeCapacityUnits = 100L)        
-        do! table.InitializeTableAsync throughput
+        let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)        
+        do! table.InitializeTableAsync(Provisioned throughput)
         let initialEntry = { Id = Guid.NewGuid() ; Value = 0L }
         let! key = table.PutItemAsync(initialEntry)
         return Counter(table, key)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ type Counter private (table : TableContext<CounterEntry>, key : TableKey) =
     static member Create(client : IAmazonDynamoDB, tableName : string) = async {
         let table = TableContext<CounterEntry>(client, tableName)
         let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)        
-        do! table.InitializeTableAsync(Throughput.Provisioned throughput)
+        do! table.CreateTableIfNotExistsAsync(Throughput.Provisioned throughput)
         let initialEntry = { Id = Guid.NewGuid() ; Value = 0L }
         let! key = table.PutItemAsync(initialEntry)
         return Counter(table, key)

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Table items can be represented using F# records:
 open FSharp.AWS.DynamoDB
 
 type WorkItemInfo =
-	{
-		[<HashKey>]
-		ProcessId : int64
-		[<RangeKey>]
-		WorkItemId : int64
+    {
+        [<HashKey>]
+        ProcessId : int64
+        [<RangeKey>]
+        WorkItemId : int64
 
-		Name : string
-		UUID : Guid
-		Dependencies : Set<string>
-		Started : DateTimeOffset option
-	}
+        Name : string
+        UUID : Guid
+        Dependencies : Set<string>
+        Started : DateTimeOffset option
+    }
 ```
 
 We can now perform table operations on DynamoDB like so:
@@ -49,7 +49,7 @@ Queries and scans can be performed using quoted predicates:
 
 ```fsharp
 let qResults = table.Query(keyCondition = <@ fun r -> r.ProcessId = 0 @>, 
-                            filterCondition = <@ fun r -> r.Name = "test" @>)
+                           filterCondition = <@ fun r -> r.Name = "test" @>)
                             
 let sResults = table.Scan <@ fun r -> r.Started.Value >= DateTimeOffset.Now - TimeSpan.FromMinutes 1.  @>
 ```
@@ -58,7 +58,7 @@ Values can be updated using quoted update expressions:
 
 ```fsharp
 let updated = table.UpdateItem(<@ fun r -> { r with Started = Some DateTimeOffset.Now } @>, 
-                                preCondition = <@ fun r -> r.DateTimeOffset = None @>)
+                               preCondition = <@ fun r -> r.DateTimeOffset = None @>)
 ```
 
 Or they can be updated using [the `SET`, `ADD`, `REMOVE` and `DELETE` operations of the UpdateOp` DSL](./src/FSharp.AWS.DynamoDB/Types.fs#263),
@@ -251,9 +251,8 @@ let processMetrics (m : RequestMetrics) =
 let table = TableContext<WorkItemInfo>(client, tableName = "workItems", metricsCollector = processMetrics)
 ```
 
-If `metricsCollector` is supplied, the requests will include `ReturnConsumedCapacity = ReturnConsumedCapacity.INDEX` 
+If `metricsCollector` is supplied, the requests will set `ReturnConsumedCapacity` to `ReturnConsumedCapacity.INDEX` 
 and the `RequestMetrics` parameter will contain a list of `ConsumedCapacity` objects returned from the DynamoDB operations.
-
 
 ### Building & Running Tests
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,15 +5,15 @@
 * Added `TryGetItemAsync` (same as `GetItemAsync`, but returns `None`, instead of throwing, if an item is not present)
 * Switched test framework to Xunit, assertions to Unquote, runner to `dotnet test` 
 * Clarified Creation/Verification APIs:
-  * Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize` and/or `TableContext.InitializeTableAsync`)
+  * Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize`, `TableContext.CreateTableIfNotExistsAsync`, `TableContext.VerifyTableAsync`)
   * Added `TableContext` constructor (replaces `TableContext.Create(verifyTable = false)`)
   * Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
   * Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
-  * Added `TableContext.InitializeTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
-  * Added `TableContext.ProvisionTableAsync` (as per `InitializeTableAsync` but does an `UpdateTableAsync` if `throughput` or `streaming` has changed)
+  * Added `TableContext.CreateTableIfNotExistsAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
+  * Added `TableContext.ProvisionTableAsync` (as per `CreateTableIfNotExistsAsync` but does an `UpdateTableAsync` if `throughput` or `streaming` has changed)
   * Added Support for `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
-  * Added ability to configure DynamoDB streaming (via `Streaming` DU) to `InitializeTableAsync` and `ProvisionTableAsync` 
-  * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `InitializeTableAsync`)
+  * Added ability to configure DynamoDB streaming (via `Streaming` DU) to `CreateTableIfNotExistsAsync` and `ProvisionTableAsync` 
+  * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `CreateTableIfNotExistsAsync`)
   * Replaced `TableKeySchemata.CreateCreateTableRequest` with `ApplyToCreateTableRequest`
 
 ### 0.9.3-beta

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 * Ensured metrics are reported even for failed requests
 * Added `TryGetItemAsync` (same as `GetItemAsync`, but returns `None`, instead of throwing, if an item is not present)
 * Switched test framework to Xunit, assertions to Unquote, runner to `dotnet test` 
+* Added `TableContext.CreateUnverified` (`TableContext.CreateAsync` without the optional store round-trips) 
 
 ### 0.9.3-beta
 * Added `RequestMetrics` record type

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,13 @@
 * Ensured metrics are reported even for failed requests
 * Added `TryGetItemAsync` (same as `GetItemAsync`, but returns `None`, instead of throwing, if an item is not present)
 * Switched test framework to Xunit, assertions to Unquote, runner to `dotnet test` 
-* Added `TableContext.CreateUnverified` (`TableContext.CreateAsync` without the optional store round-trips) 
+* Clarified Creation/Verification APIs:
+  * Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize` and/or `TableContext.InitializeTableAsync`)
+  * Added `TableContext` constructor (replaces `TableContext.Create(verifyTable = false)`)
+  * Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
+  * Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
+  * Added `TableContext.InitializeTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
+  * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `TableContext.InitializeTableAsync`)
 
 ### 0.9.3-beta
 * Added `RequestMetrics` record type

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
 ### 0.10.0-beta
 * Added `TableContext` constructor (replaces `TableContext.Create(verifyTable = false)`)
-* Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
 * Added `TableContext.VerifyOrCreateTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
 * Added `TableContext.UpdateTableIfRequiredAsync` (conditional `UpdateTableAsync` to establish specified `throughput` or `streaming` only if required. Replaces `UpdateProvisionedThroughputAsync`)
-* Added `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
-* Added ability to configure DynamoDB streaming (via `Streaming` DU) to `VerifyOrCreateTableAsync` and `UpdateTableIfRequiredAsync` 
+* Added `TableContext.Scripting.Initialize` (two overloads, replacing `TableContext.Create()` and `TableContext.Create(createIfNotExists = true)`)
+* Added `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST`, to go with the existing support for configuring `PROVISIONED` and a `ProvisionedThroughput`)
+* Added ability to configure DynamoDB streaming (via a `Streaming` DU) to `VerifyOrCreateTableAsync` and `UpdateTableIfRequiredAsync` 
 * Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize`, `TableContext.VerifyOrCreateTableAsync`, `TableContext.VerifyTableAsync`)
 * Obsoleted `TableContext.UpdateProvisionedThroughputAsync` (replace with `TableContext.UpdateTableIfRequiredAsync`)
 * (breaking) Obsoleted `TableContext.VerifyTableAsync` optional argument to create a Table (replace with `VerifyOrCreateTableAsync`)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
   * Added Support for `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
   * Added ability to configure DynamoDB streaming (via `Streaming` DU) to `InitializeTableAsync` and `ProvisionTableAsync` 
   * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `InitializeTableAsync`)
+  * Replaced `TableKeySchemata.CreateCreateTableRequest` with `ApplyToCreateTableRequest`
 
 ### 0.9.3-beta
 * Added `RequestMetrics` record type

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,15 +5,15 @@
 * Added `TryGetItemAsync` (same as `GetItemAsync`, but returns `None`, instead of throwing, if an item is not present)
 * Switched test framework to Xunit, assertions to Unquote, runner to `dotnet test` 
 * Clarified Creation/Verification APIs:
-  * Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize`, `TableContext.CreateTableIfNotExistsAsync`, `TableContext.VerifyTableAsync`)
+  * Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize`, `TableContext.VerifyOrCreateTableAsync`, `TableContext.VerifyTableAsync`)
   * Added `TableContext` constructor (replaces `TableContext.Create(verifyTable = false)`)
   * Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
   * Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
-  * Added `TableContext.CreateTableIfNotExistsAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
-  * Added `TableContext.ProvisionTableAsync` (as per `CreateTableIfNotExistsAsync` but does an `UpdateTableAsync` if `throughput` or `streaming` has changed)
-  * Added Support for `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
-  * Added ability to configure DynamoDB streaming (via `Streaming` DU) to `CreateTableIfNotExistsAsync` and `ProvisionTableAsync` 
-  * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `CreateTableIfNotExistsAsync`)
+  * Added `TableContext.VerifyOrCreateTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
+  * Added `TableContext.UpdateTableIfRequiredAsync` (conditional `UpdateTableAsync` to establish specified `throughput` or `streaming` only if required)
+  * Added `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
+  * Added ability to configure DynamoDB streaming (via `Streaming` DU) to `VerifyOrCreateTableAsync` and `UpdateTableIfRequiredAsync` 
+  * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `VerifyOrCreateTableAsync`)
   * Replaced `TableKeySchemata.CreateCreateTableRequest` with `ApplyToCreateTableRequest`
 
 ### 0.9.3-beta

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,8 +10,9 @@
   * Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
   * Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
   * Added `TableContext.InitializeTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
-  * Added `TableContext.ProvisionTableAsync` (as per `InitializeTableAsync` but does an `UpdateProvisionedThroughputAsync` if throughput has changed)
+  * Added `TableContext.ProvisionTableAsync` (as per `InitializeTableAsync` but does an `UpdateTableAsync` if `throughput` or `streaming` has changed)
   * Added Support for `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
+  * Added ability to configure DynamoDB streaming (via `Streaming` DU) to `InitializeTableAsync` and `ProvisionTableAsync` 
   * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `InitializeTableAsync`)
 
 ### 0.9.3-beta

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,20 +1,21 @@
+### 0.10.0-beta
+* Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize`, `TableContext.VerifyOrCreateTableAsync`, `TableContext.VerifyTableAsync`)
+* Added `TableContext` constructor (replaces `TableContext.Create(verifyTable = false)`)
+* Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
+* Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
+* Added `TableContext.VerifyOrCreateTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
+* Added `TableContext.UpdateTableIfRequiredAsync` (conditional `UpdateTableAsync` to establish specified `throughput` or `streaming` only if required)
+* Added `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
+* Added ability to configure DynamoDB streaming (via `Streaming` DU) to `VerifyOrCreateTableAsync` and `UpdateTableIfRequiredAsync` 
+* Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `VerifyOrCreateTableAsync`)
+* Replaced `TableKeySchemata.CreateCreateTableRequest` with `ApplyToCreateTableRequest`
+
 ### 0.9.4-beta
 * Moved Sync-over-Async versions of `TableContext` operations into `namespace FSharp.AWS.DynamoDB.Scripting`
 * Added `WithMetricsCollector()` copy method to allow separating metrics by context (eg by request)
 * Ensured metrics are reported even for failed requests
 * Added `TryGetItemAsync` (same as `GetItemAsync`, but returns `None`, instead of throwing, if an item is not present)
 * Switched test framework to Xunit, assertions to Unquote, runner to `dotnet test` 
-* Clarified Creation/Verification APIs:
-  * Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize`, `TableContext.VerifyOrCreateTableAsync`, `TableContext.VerifyTableAsync`)
-  * Added `TableContext` constructor (replaces `TableContext.Create(verifyTable = false)`)
-  * Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
-  * Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
-  * Added `TableContext.VerifyOrCreateTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
-  * Added `TableContext.UpdateTableIfRequiredAsync` (conditional `UpdateTableAsync` to establish specified `throughput` or `streaming` only if required)
-  * Added `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
-  * Added ability to configure DynamoDB streaming (via `Streaming` DU) to `VerifyOrCreateTableAsync` and `UpdateTableIfRequiredAsync` 
-  * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `VerifyOrCreateTableAsync`)
-  * Replaced `TableKeySchemata.CreateCreateTableRequest` with `ApplyToCreateTableRequest`
 
 ### 0.9.3-beta
 * Added `RequestMetrics` record type

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@
   * Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
   * Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
   * Added `TableContext.InitializeTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
-  * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `TableContext.InitializeTableAsync`)
+  * Added `TableContext.ProvisionTableAsync` (as per `InitializeTableAsync` but does an `UpdateProvisionedThroughputAsync` if throughput has changed)
+  * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `InitializeTableAsync`)
 
 ### 0.9.3-beta
 * Added `RequestMetrics` record type

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
   * Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
   * Added `TableContext.InitializeTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
   * Added `TableContext.ProvisionTableAsync` (as per `InitializeTableAsync` but does an `UpdateProvisionedThroughputAsync` if throughput has changed)
+  * Added Support for `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
   * Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `InitializeTableAsync`)
 
 ### 0.9.3-beta

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,15 @@
 ### 0.10.0-beta
-* Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize`, `TableContext.VerifyOrCreateTableAsync`, `TableContext.VerifyTableAsync`)
 * Added `TableContext` constructor (replaces `TableContext.Create(verifyTable = false)`)
 * Added `TableContext.Scripting.Initialize` (replaces `TableContext.Create()`)
-* Added `TableContext.VerifyTableAsync` overload that only performs verification but never creates a Table
 * Added `TableContext.VerifyOrCreateTableAsync` (replaces `TableContext.VerifyTableAsync(createIfNotExists = true)`)
-* Added `TableContext.UpdateTableIfRequiredAsync` (conditional `UpdateTableAsync` to establish specified `throughput` or `streaming` only if required)
+* Added `TableContext.UpdateTableIfRequiredAsync` (conditional `UpdateTableAsync` to establish specified `throughput` or `streaming` only if required. Replaces `UpdateProvisionedThroughputAsync`)
 * Added `Throughput.OnDemand` mode (sets `BillingMode` to `PAY_PER_REQUEST` rather than attempting to configure a `ProvisionedThroughput`)
 * Added ability to configure DynamoDB streaming (via `Streaming` DU) to `VerifyOrCreateTableAsync` and `UpdateTableIfRequiredAsync` 
-* Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `VerifyOrCreateTableAsync`)
-* Replaced `TableKeySchemata.CreateCreateTableRequest` with `ApplyToCreateTableRequest`
+* Obsoleted `TableContext.Create` (replace with `TableContext.Scripting.Initialize`, `TableContext.VerifyOrCreateTableAsync`, `TableContext.VerifyTableAsync`)
+* Obsoleted `TableContext.UpdateProvisionedThroughputAsync` (replace with `TableContext.UpdateTableIfRequiredAsync`)
+* (breaking) Obsoleted `TableContext.VerifyTableAsync` optional argument to create a Table (replace with `VerifyOrCreateTableAsync`)
+* (breaking) Changed `TableKeySchemata.CreateCreateTableRequest` to `ApplyToCreateTableRequest` (with minor signature change)
+* (breaking) Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `VerifyOrCreateTableAsync`)
 
 ### 0.9.4-beta
 * Moved Sync-over-Async versions of `TableContext` operations into `namespace FSharp.AWS.DynamoDB.Scripting`

--- a/src/FSharp.AWS.DynamoDB/FSharp.AWS.DynamoDB.fsproj
+++ b/src/FSharp.AWS.DynamoDB/FSharp.AWS.DynamoDB.fsproj
@@ -9,6 +9,7 @@
     <Company />
     <Copyright>Copyright 2016</Copyright>
     <Product />
+    <PackageLicense>MIT</PackageLicense>
     <PackageLicenseUrl>https://github.com/fsprojects/FSharp.AWS.DynamoDB/blob/master/License.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/fsprojects/FSharp.AWS.DynamoDB</PackageProjectUrl>
     <PackageIconUrl>https://avatars0.githubusercontent.com/u/6001315</PackageIconUrl>

--- a/src/FSharp.AWS.DynamoDB/RecordKeySchema.fs
+++ b/src/FSharp.AWS.DynamoDB/RecordKeySchema.fs
@@ -368,9 +368,8 @@ type TableKeySchemata with
                 yield! td.GlobalSecondaryIndexes |> Seq.map mkGlobalSecondaryIndex
                 yield! td.LocalSecondaryIndexes |> Seq.map mkLocalSecondaryIndex |])
 
-    /// Create a CreateTableRequest using supplied key schema
-    member schema.CreateCreateTableRequest(tableName : string) =
-        let ctr = CreateTableRequest(TableName = tableName)
+    /// Applies the settings implied by the schema to the supplied CreateTableRequest
+    member schema.ApplyToCreateTableRequest(ctr : CreateTableRequest) =
         let inline mkKSE n t = KeySchemaElement(n, t)
 
         let keyAttrs = new Dictionary<string, KeyAttributeSchema>()
@@ -402,5 +401,3 @@ type TableKeySchemata with
         for attr in keyAttrs.Values do
             let ad = AttributeDefinition(attr.AttributeName, attr.KeyType)
             ctr.AttributeDefinitions.Add ad
-
-        ctr

--- a/src/FSharp.AWS.DynamoDB/RecordKeySchema.fs
+++ b/src/FSharp.AWS.DynamoDB/RecordKeySchema.fs
@@ -369,11 +369,9 @@ type TableKeySchemata with
                 yield! td.LocalSecondaryIndexes |> Seq.map mkLocalSecondaryIndex |])
 
     /// Create a CreateTableRequest using supplied key schema
-    member schema.CreateCreateTableRequest (tableName : string, provisionedThroughput : ProvisionedThroughput) =
+    member schema.CreateCreateTableRequest(tableName : string) =
         let ctr = CreateTableRequest(TableName = tableName)
         let inline mkKSE n t = KeySchemaElement(n, t)
-
-        ctr.ProvisionedThroughput <- provisionedThroughput
 
         let keyAttrs = new Dictionary<string, KeyAttributeSchema>()
         for tks in schema.Schemata do
@@ -391,7 +389,6 @@ type TableKeySchemata with
                 gsi.KeySchema.Add <| mkKSE tks.HashKey.AttributeName KeyType.HASH
                 tks.RangeKey |> Option.iter (fun rk -> gsi.KeySchema.Add <| mkKSE rk.AttributeName KeyType.RANGE)
                 gsi.Projection <- Projection(ProjectionType = ProjectionType.ALL)
-                gsi.ProvisionedThroughput <- provisionedThroughput
                 ctr.GlobalSecondaryIndexes.Add gsi
 
             | LocalSecondaryIndex name ->

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -15,10 +15,9 @@ open FSharp.AWS.DynamoDB
 open FSharp.AWS.DynamoDB.Scripting // non-Async overloads
 
 #if USE_CLOUD
-open Amazon
-open Amazon.Util
-let account = AWSCredentialsProfile.LoadFrom("default").Credentials
-let ddb = new AmazonDynamoDBClient(account, RegionEndpoint.EUCentral1) :> IAmazonDynamoDB
+open Amazon.DynamoDBv2
+let ok, creds = CredentialProfileStoreChain().TryGetAWSCredentials("default")
+let ddb = if ok then new AmazonDynamoDBClient(creds) :> IAmazonDynamoDB else failwith "Unable to load default credentials"
 #else // Use Docker-hosted dynamodb-local instance
 // See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#docker for details of how to deploy a simulator instance
 #if USE_CREDS_FROM_ENV_VARS // 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY' must be set for this to work

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -128,7 +128,7 @@ type EasyCounters private (table : TableContext<CounterEntry>) =
         // Create the table if necessary. Verifies schema is correct if it has already been created
         // NOTE the hard coded initial throughput provisioning - arguably this belongs outside of your application logic
         let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
-        do! table.InitializeTableAsync(Throughput.Provisioned throughput)
+        do! table.CreateTableIfNotExistsAsync(Throughput.Provisioned throughput)
         return EasyCounters(table)
     }
 
@@ -141,7 +141,7 @@ type SimpleCounters private (table : TableContext<CounterEntry>) =
     static member Provision(client : IAmazonDynamoDB, tableName : string, readCapacityUnits, writeCapacityUnits) : Async<unit> =
         let table = TableContext<CounterEntry>(client, tableName)
         // normally, RCU/WCU provisioning only happens first time the Table is created and is then considered an external concern
-        // here we use `ProvisionTableAsync` instead of `InitializeTableAsync` to reset it each time we deploy the app
+        // here we use `ProvisionTableAsync` instead of `CreateTableIfNotExistsAsync` to reset it each time we deploy the app
         let provisionedThroughput = ProvisionedThroughput(readCapacityUnits, writeCapacityUnits)
         table.ProvisionTableAsync(Throughput.Provisioned provisionedThroughput)
 

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -16,7 +16,7 @@ open FSharp.AWS.DynamoDB.Scripting // non-Async overloads
 
 #if USE_CLOUD
 open Amazon.DynamoDBv2
-let ok, creds = CredentialProfileStoreChain().TryGetAWSCredentials("default")
+let ok, creds = Amazon.Runtime.CredentialManagement.CredentialProfileStoreChain().TryGetAWSCredentials("default")
 let ddb = if ok then new AmazonDynamoDBClient(creds) :> IAmazonDynamoDB else failwith "Unable to load default credentials"
 #else // Use Docker-hosted dynamodb-local instance
 // See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#docker for details of how to deploy a simulator instance

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -141,7 +141,7 @@ type SimpleCounters private (table : TableContext<CounterEntry>) =
     static member Provision(client : IAmazonDynamoDB, tableName : string, readCapacityUnits, writeCapacityUnits) : Async<unit> =
         let table = TableContext<CounterEntry>(client, tableName)
         // normally, RCU/WCU provisioning only happens first time the Table is created and is then considered an external concern
-        // here we use `ProvisionTableAsync` instead of `InitializeAsync` to reset it each time we start the app
+        // here we use `ProvisionTableAsync` instead of `InitializeTableAsync` to reset it each time we deploy the app
         let provisionedThroughput = ProvisionedThroughput(readCapacityUnits, writeCapacityUnits)
         table.ProvisionTableAsync(Throughput.Provisioned provisionedThroughput)
 

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -55,7 +55,7 @@ type Test =
     }
 
 let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
-let table = TableContext.Initialize<Test>(ddb, "test", Provisioned throughput)
+let table = TableContext.Initialize<Test>(ddb, "test", Throughput.Provisioned throughput)
 
 let value = { HashKey = Guid.NewGuid() ; List = [] ; RangeKey = "2" ; Value = 3.1415926 ; Date = DateTimeOffset.Now + TimeSpan.FromDays 2. ; Value2 = None ; Values = [|{ A = "foo" ; B = System.Reflection.BindingFlags.Instance }|] ; Map = Map.ofList [("A1",1)] ; Set = [set [1L];set [2L]] ; Bytes = [|1uy..10uy|]; String = ref "1a" ; Unions = [A 42; B("42",3)]}
 
@@ -128,7 +128,7 @@ type EasyCounters private (table : TableContext<CounterEntry>) =
         // Create the table if necessary. Verifies schema is correct if it has already been created
         // NOTE the hard coded initial throughput provisioning - arguably this belongs outside of your application logic
         let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
-        do! table.InitializeTableAsync(Provisioned throughput)
+        do! table.InitializeTableAsync(Throughput.Provisioned throughput)
         return EasyCounters(table)
     }
 
@@ -143,7 +143,7 @@ type SimpleCounters private (table : TableContext<CounterEntry>) =
         // normally, RCU/WCU provisioning only happens first time the Table is created and is then considered an external concern
         // here we use `ProvisionTableAsync` instead of `InitializeAsync` to reset it each time we start the app
         let provisionedThroughput = ProvisionedThroughput(readCapacityUnits, writeCapacityUnits)
-        table.ProvisionTableAsync(Provisioned provisionedThroughput)
+        table.ProvisionTableAsync(Throughput.Provisioned provisionedThroughput)
 
     /// We only want to do the initialization bit once per instance of our application
     /// Similar to EasyCounters.Create in that it ensures the table is provisioned correctly

--- a/src/FSharp.AWS.DynamoDB/Script.fsx
+++ b/src/FSharp.AWS.DynamoDB/Script.fsx
@@ -128,7 +128,7 @@ type EasyCounters private (table : TableContext<CounterEntry>) =
         // Create the table if necessary. Verifies schema is correct if it has already been created
         // NOTE the hard coded initial throughput provisioning - arguably this belongs outside of your application logic
         let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
-        do! table.CreateTableIfNotExistsAsync(Throughput.Provisioned throughput)
+        do! table.VerifyOrCreateTableAsync(Throughput.Provisioned throughput)
         return EasyCounters(table)
     }
 
@@ -138,16 +138,21 @@ type EasyCounters private (table : TableContext<CounterEntry>) =
 /// Variant of EasyCounters that splits the provisioning step from the (optional) validation that the table is present
 type SimpleCounters private (table : TableContext<CounterEntry>) =
 
-    static member Provision(client : IAmazonDynamoDB, tableName : string, readCapacityUnits, writeCapacityUnits) : Async<unit> =
+    static member Provision(client : IAmazonDynamoDB, tableName : string, readCapacityUnits, writeCapacityUnits) : Async<unit> = async {
         let table = TableContext<CounterEntry>(client, tableName)
-        // normally, RCU/WCU provisioning only happens first time the Table is created and is then considered an external concern
-        // here we use `ProvisionTableAsync` instead of `CreateTableIfNotExistsAsync` to reset it each time we deploy the app
         let provisionedThroughput = ProvisionedThroughput(readCapacityUnits, writeCapacityUnits)
-        table.ProvisionTableAsync(Throughput.Provisioned provisionedThroughput)
+        let throughput = Throughput.Provisioned provisionedThroughput
+        // normally, RCU/WCU provisioning only happens first time the Table is created and is then considered an external concern
+        // here we use `UpdateTableIfRequiredAsync` to reset it each time we deploy the app
+        do! table.VerifyOrCreateTableAsync(throughput)
+        do! table.UpdateTableIfRequiredAsync(throughput) }
 
-    static member ProvisionOnDemand(client : IAmazonDynamoDB, tableName : string) : Async<unit> =
+    static member ProvisionOnDemand(client : IAmazonDynamoDB, tableName : string) : Async<unit> = async {
         let table = TableContext<CounterEntry>(client, tableName)
-        table.ProvisionTableAsync(Throughput.OnDemand)
+        let throughput = Throughput.OnDemand
+        do! table.VerifyOrCreateTableAsync(throughput)
+        // as per the Provision, above, we reset to OnDemand, if it got reconfigured since it was originally created
+        do! table.UpdateTableIfRequiredAsync(throughput) }
 
     /// We only want to do the initialization bit once per instance of our application
     /// Similar to EasyCounters.Create in that it ensures the table is provisioned correctly

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -909,8 +909,10 @@ type TableContext<'TRecord> internal
                 match mode with
                 | InitializationMode.VerifyOnly | InitializationMode.CreateIfNotExists _ -> ()
                 | InitializationMode.CreateOrUpdateThroughput t ->
-                    // TODO make this not throw when its a null update
-                    do! __.UpdateProvisionedThroughputAsync(t)
+                    let provisioned = td.Table.ProvisionedThroughput
+                    if t.ReadCapacityUnits <> provisioned.ReadCapacityUnits
+                        || t.WriteCapacityUnits <> provisioned.WriteCapacityUnits then
+                        do! __.UpdateProvisionedThroughputAsync(t)
 
             | Choice2Of2 (:? ResourceNotFoundException) when mode <> InitializationMode.VerifyOnly ->
                 let throughput =

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -1133,11 +1133,8 @@ module Scripting =
         /// <param name="client">DynamoDB client instance.</param>
         /// <param name="tableName">Table name to target.</param>
         /// <param name="throughput">Optional throughput to configure if the Table does not yet exist.</param>
-        /// <param name="metricsCollector">Function to receive request metrics.</param>
-        static member Initialize<'TRecord>
-            (   client : IAmazonDynamoDB, tableName : string, ?throughput,
-                ?metricsCollector : RequestMetrics -> unit) : TableContext<'TRecord> =
-            let context = TableContext<'TRecord>(client, tableName, ?metricsCollector = metricsCollector)
+        static member Initialize<'TRecord>(client : IAmazonDynamoDB, tableName : string, ?throughput) : TableContext<'TRecord> =
+            let context = TableContext<'TRecord>(client, tableName)
             match throughput with
             | None -> context.VerifyTableAsync() |> Async.RunSynchronously
             | Some t -> context.VerifyOrCreateTableAsync(t) |> Async.RunSynchronously

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -1060,24 +1060,11 @@ type TableContext<'TRecord> internal
         | None -> ()
         | Some request -> do! UpdateTableRequest.execute client request }
 
-    /// <summary>
-    /// Asynchronously updates the underlying table with supplied configuration.<br/>
-    /// NOTE: The underlying API can throw if none the options represent a change or a change is in currently progress; see the DynamoDB <a href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html"><c>UpdateTable</c> API documentation</a>.
-    /// </summary>
-    /// <param name="throughput">Optional Throughput configuration to apply.</param>
-    /// <param name="streaming">Optional Streaming configuration to apply.</param>
-    /// <param name="customize">Callback to apply any further options desired.</param>
-    member _.UpdateTableAsync(?throughput, ?streaming, ?customize : UpdateTableRequest -> unit) : Async<unit> =
-        let request = UpdateTableRequest.create tableName
-        UpdateTableRequest.apply throughput streaming request
-        customize |> Option.iter (fun c -> c request)
-        UpdateTableRequest.execute client request
-
     /// <summary>Asynchronously updates the underlying table with supplied provisioned throughput.</summary>
     /// <param name="provisionedThroughput">Provisioned throughput to use on table.</param>
-    [<System.Obsolete("Please replace with either 1. UpdateTableAsync or 2. UpdateTableIfRequiredAsync")>]
+    [<System.Obsolete("Please replace with UpdateTableIfRequiredAsync")>]
     member t.UpdateProvisionedThroughputAsync(provisionedThroughput : ProvisionedThroughput) : Async<unit> =
-        t.UpdateTableAsync(Throughput.Provisioned provisionedThroughput)
+        t.UpdateTableIfRequiredAsync(Throughput.Provisioned provisionedThroughput)
 
     /// <summary>Asynchronously verify that the table exists and is compatible with record key schema.</summary>
     /// <param name="createIfNotExists">Create the table instance now instance if it does not exist. Defaults to false.</param>
@@ -1551,10 +1538,8 @@ module Scripting =
             |> Async.RunSynchronously
 
 
-        /// <summary>
-        ///     Updates the underlying table with supplied provisioned throughput.
-        /// </summary>
+        /// <summary>Updates the underlying table with supplied provisioned throughput.</summary>
         /// <param name="provisionedThroughput">Provisioned throughput to use on table.</param>
         member t.UpdateProvisionedThroughput(provisionedThroughput : ProvisionedThroughput) =
             let spec = Throughput.Provisioned provisionedThroughput
-            t.UpdateTableAsync(spec) |> Async.RunSynchronously
+            t.UpdateTableIfRequiredAsync(spec) |> Async.RunSynchronously

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -908,7 +908,9 @@ type TableContext<'TRecord> internal
                     |> invalidOp
                 match mode with
                 | InitializationMode.VerifyOnly | InitializationMode.CreateIfNotExists _ -> ()
-                | InitializationMode.CreateOrUpdateThroughput t -> do! __.UpdateProvisionedThroughputAsync(t)
+                | InitializationMode.CreateOrUpdateThroughput t ->
+                    // TODO make this not throw when its a null update
+                    do! __.UpdateProvisionedThroughputAsync(t)
 
             | Choice2Of2 (:? ResourceNotFoundException) when mode <> InitializationMode.VerifyOnly ->
                 let throughput =
@@ -986,7 +988,7 @@ type TableContext internal () =
     /// <param name="tableName">Table name to target.</param>
     /// <param name="verifyTable">Verify that the table exists and is compatible with supplied record schema. Defaults to true.</param>
     /// <param name="createIfNotExists">Create the table now if it does not exist. Defaults to false.</param>
-    /// <param name="provisionedThroughput">Provisioned throughput for the table if newly created.</param>
+    /// <param name="provisionedThroughput">Provisioned throughput for the table if newly created. Default: 10 RCU, 10 WCU</param>
     /// <param name="metricsCollector">Function to receive request metrics.</param>
     [<System.Obsolete(@"Creation with synchronous verification has been deprecated. Please use either
                         1. TableContext constructor (optionally followed by VerifyTableAsync or InitializeTableAsync) OR

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -1113,18 +1113,30 @@ type TableContext internal () =
 /// </summary>
 module Scripting =
 
-    /// Factory method that allows one to include auto-initialization easily for scripting scenarios
+    /// Factory methods for scripting scenarios
     type TableContext internal () =
 
-        /// <summary>Creates a DynamoDB client instance for the specified F# record type, client and table name.</summary>
+        /// <summary>
+        /// Creates a DynamoDB client instance for the specified F# record type, client and table name.<br/>
+        /// Validates the table exists, and has the correct schema as per <c>VerifyTableAsync</c>.<br/>
+        /// See other overload for <c>VerifyOrCreateTableAsync</c> semantics.
+        /// </summary>
         /// <param name="client">DynamoDB client instance.</param>
         /// <param name="tableName">Table name to target.</param>
-        /// <param name="throughput">Optional throughput to configure if the Table does not yet exist.</param>
-        static member Initialize<'TRecord>(client : IAmazonDynamoDB, tableName : string, ?throughput) : TableContext<'TRecord> =
+        static member Initialize<'TRecord>(client : IAmazonDynamoDB, tableName : string) : TableContext<'TRecord> =
             let context = TableContext<'TRecord>(client, tableName)
-            match throughput with
-            | None -> context.VerifyTableAsync() |> Async.RunSynchronously
-            | Some t -> context.VerifyOrCreateTableAsync(t) |> Async.RunSynchronously
+            context.VerifyTableAsync() |> Async.RunSynchronously
+            context
+
+        /// Creates a DynamoDB client instance for the specified F# record type, client and table name.<br/>
+        /// Either validates the table exists and has the correct schema, or creates a fresh one, as per <c>VerifyOrCreateTableAsync</c>.<br/>
+        /// See other overload for <c>VerifyTableAsync</c> semantics.
+        /// <param name="client">DynamoDB client instance.</param>
+        /// <param name="tableName">Table name to target.</param>
+        /// <param name="throughput">Throughput to configure if the Table does not yet exist.</param>
+        static member Initialize<'TRecord>(client : IAmazonDynamoDB, tableName : string, throughput) : TableContext<'TRecord> =
+            let context = TableContext<'TRecord>(client, tableName)
+            context.VerifyOrCreateTableAsync(throughput) |> Async.RunSynchronously
             context
 
     type TableContext<'TRecord> with

--- a/tests/FSharp.AWS.DynamoDB.Tests/ConditionalExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/ConditionalExpressionTests.fs
@@ -86,7 +86,7 @@ type ``Conditional Expression Tests`` (fixture : TableFixture) =
             Serialized = rand(), guid()
         }
 
-    let table = TableContext.Create<CondExprRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let table = fixture.CreateContextAndTableIfNotExists<CondExprRecord>()
 
     let [<Fact>] ``Item exists precondition`` () =
         let item = mkItem()

--- a/tests/FSharp.AWS.DynamoDB.Tests/ConditionalExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/ConditionalExpressionTests.fs
@@ -86,7 +86,7 @@ type ``Conditional Expression Tests`` (fixture : TableFixture) =
             Serialized = rand(), guid()
         }
 
-    let table = fixture.CreateContextAndTableIfNotExists<CondExprRecord>()
+    let table = fixture.CreateEmpty<CondExprRecord>()
 
     let [<Fact>] ``Item exists precondition`` () =
         let item = mkItem()

--- a/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
@@ -52,7 +52,7 @@ let (|TotalCu|) : ConsumedCapacity list -> float = Seq.sumBy (fun c -> c.Capacit
 /// Tests without common setup
 type Tests(fixture : TableFixture) =
 
-    let rawTable = fixture.CreateContextAndTableIfNotExists<MetricsRecord>()
+    let rawTable = fixture.CreateEmpty<MetricsRecord>()
 
     let (|ExpectedTableName|_|) name = if name = fixture.TableName then Some () else None
 
@@ -84,7 +84,7 @@ type Tests(fixture : TableFixture) =
 /// Tests that look up a specific item. Each test run gets a fresh individual item
 type ItemTests(fixture : TableFixture) =
 
-    let rawTable = fixture.CreateContextAndTableIfNotExists<MetricsRecord>()
+    let rawTable = fixture.CreateEmpty<MetricsRecord>()
     let (|ExpectedTableName|_|) name = if name = fixture.TableName then Some () else None
 
     let item = mkItem (guid()) (guid()) 0
@@ -131,7 +131,7 @@ type ItemTests(fixture : TableFixture) =
 /// Heavy tests reliant on establishing (and mutating) multiple items. Separate Test Class so Xunit will run them in parallel with others
 type BulkMutationTests(fixture : TableFixture) =
 
-    let rawTable = fixture.CreateContextAndTableIfNotExists<MetricsRecord>()
+    let rawTable = fixture.CreateEmpty<MetricsRecord>()
     let (|ExpectedTableName|_|) name = if name = fixture.TableName then Some () else None
 
     // NOTE we mutate the items so they need to be established each time
@@ -169,7 +169,7 @@ type ManyReadOnlyItemsFixture() =
     inherit TableFixture()
 
     // TOCONSIDER shift this into IAsyncLifetime.InitializeAsync
-    let table = base.CreateContextAndTableIfNotExists<MetricsRecord>()
+    let table = base.CreateEmpty<MetricsRecord>()
 
     let hk = guid ()
     do  let gsk = guid ()

--- a/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
@@ -52,7 +52,7 @@ let (|TotalCu|) : ConsumedCapacity list -> float = Seq.sumBy (fun c -> c.Capacit
 /// Tests without common setup
 type Tests(fixture : TableFixture) =
 
-    let rawTable = TableContext.Create<MetricsRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let rawTable = fixture.CreateContextAndTableIfNotExists<MetricsRecord>()
 
     let (|ExpectedTableName|_|) name = if name = fixture.TableName then Some () else None
 
@@ -84,7 +84,7 @@ type Tests(fixture : TableFixture) =
 /// Tests that look up a specific item. Each test run gets a fresh individual item
 type ItemTests(fixture : TableFixture) =
 
-    let rawTable = TableContext.Create<MetricsRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let rawTable = fixture.CreateContextAndTableIfNotExists<MetricsRecord>()
     let (|ExpectedTableName|_|) name = if name = fixture.TableName then Some () else None
 
     let item = mkItem (guid()) (guid()) 0
@@ -128,10 +128,10 @@ type ItemTests(fixture : TableFixture) =
 
     interface IClassFixture<TableFixture>
 
-/// Heavy tests reliant on establishing (and mutating) multiple items. Separate Test Class so Xunit will run thme in parallel with others
+/// Heavy tests reliant on establishing (and mutating) multiple items. Separate Test Class so Xunit will run them in parallel with others
 type BulkMutationTests(fixture : TableFixture) =
 
-    let rawTable = TableContext.Create<MetricsRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let rawTable = fixture.CreateContextAndTableIfNotExists<MetricsRecord>()
     let (|ExpectedTableName|_|) name = if name = fixture.TableName then Some () else None
 
     // NOTE we mutate the items so they need to be established each time
@@ -169,7 +169,7 @@ type ManyReadOnlyItemsFixture() =
     inherit TableFixture()
 
     // TOCONSIDER shift this into IAsyncLifetime.InitializeAsync
-    let table = TableContext.Create<MetricsRecord>(base.Client, base.TableName, createIfNotExists = true)
+    let table = base.CreateContextAndTableIfNotExists<MetricsRecord>()
 
     let hk = guid ()
     do  let gsk = guid ()

--- a/tests/FSharp.AWS.DynamoDB.Tests/PaginationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/PaginationTests.fs
@@ -43,7 +43,7 @@ type ``Pagination Tests`` (fixture : TableFixture) =
             LocalAttribute = int (rand () % 2L)
         }
 
-    let table = TableContext.Create<PaginationRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let table = fixture.CreateContextAndTableIfNotExists<PaginationRecord>()
 
     let [<Fact>] ``Paginated Query on Primary Key`` () =
         let hk = guid()

--- a/tests/FSharp.AWS.DynamoDB.Tests/PaginationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/PaginationTests.fs
@@ -43,7 +43,7 @@ type ``Pagination Tests`` (fixture : TableFixture) =
             LocalAttribute = int (rand () % 2L)
         }
 
-    let table = fixture.CreateContextAndTableIfNotExists<PaginationRecord>()
+    let table = fixture.CreateEmpty<PaginationRecord>()
 
     let [<Fact>] ``Paginated Query on Primary Key`` () =
         let hk = guid()

--- a/tests/FSharp.AWS.DynamoDB.Tests/ProjectionExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/ProjectionExpressionTests.fs
@@ -97,7 +97,7 @@ type ``Projection Expression Tests`` (fixture : TableFixture) =
             Serialized = rand(), guid() ; Serialized2 = { NV = guid() ; NE = enum<Enum> (int (rand()) % 3) } ;
         }
 
-    let table = fixture.CreateContextAndTableIfNotExists<ProjectionExprRecord>()
+    let table = fixture.CreateEmpty<ProjectionExprRecord>()
 
     let [<Fact>] ``Should fail on invalid projections`` () =
         let testProj (p : Expr<R -> 'T>) =

--- a/tests/FSharp.AWS.DynamoDB.Tests/ProjectionExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/ProjectionExpressionTests.fs
@@ -97,7 +97,7 @@ type ``Projection Expression Tests`` (fixture : TableFixture) =
             Serialized = rand(), guid() ; Serialized2 = { NV = guid() ; NE = enum<Enum> (int (rand()) % 3) } ;
         }
 
-    let table = TableContext.Create<ProjectionExprRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let table = fixture.CreateContextAndTableIfNotExists<ProjectionExprRecord>()
 
     let [<Fact>] ``Should fail on invalid projections`` () =
         let testProj (p : Expr<R -> 'T>) =

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -56,7 +56,7 @@ type ``Simple Table Operation Tests`` (fixture : TableFixture) =
             Unions = [Choice1Of3 (guid()) ; Choice2Of3(rand()) ; Choice3Of3(Guid.NewGuid().ToByteArray())]
         }
 
-    let table = fixture.CreateContextAndTableIfNotExists<SimpleRecord>()
+    let table = fixture.CreateEmpty<SimpleRecord>()
 
     let [<Fact>] ``Convert to compatible table`` () =
         let table' = table.WithRecordType<CompatibleRecord> ()

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -56,7 +56,7 @@ type ``Simple Table Operation Tests`` (fixture : TableFixture) =
             Unions = [Choice1Of3 (guid()) ; Choice2Of3(rand()) ; Choice3Of3(Guid.NewGuid().ToByteArray())]
         }
 
-    let table = TableContext.Create<SimpleRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let table = fixture.CreateContextAndTableIfNotExists<SimpleRecord>()
 
     let [<Fact>] ``Convert to compatible table`` () =
         let table' = table.WithRecordType<CompatibleRecord> ()

--- a/tests/FSharp.AWS.DynamoDB.Tests/SparseGSITests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SparseGSITests.fs
@@ -31,7 +31,7 @@ type ``Sparse GSI Tests`` (fixture : TableFixture) =
             SecondaryHashKey = if rand() % 2L = 0L then Some (guid()) else None ;
         }
 
-    let table = TableContext.Create<GsiRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let table = fixture.CreateContextAndTableIfNotExists<GsiRecord>()
 
     let [<Fact>] ``GSI Put Operation`` () =
         let value = mkItem()

--- a/tests/FSharp.AWS.DynamoDB.Tests/SparseGSITests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SparseGSITests.fs
@@ -31,7 +31,7 @@ type ``Sparse GSI Tests`` (fixture : TableFixture) =
             SecondaryHashKey = if rand() % 2L = 0L then Some (guid()) else None ;
         }
 
-    let table = fixture.CreateContextAndTableIfNotExists<GsiRecord>()
+    let table = fixture.CreateEmpty<GsiRecord>()
 
     let [<Fact>] ``GSI Put Operation`` () =
         let value = mkItem()

--- a/tests/FSharp.AWS.DynamoDB.Tests/UpdateExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/UpdateExpressionTests.fs
@@ -94,7 +94,7 @@ type ``Update Expression Tests``(fixture : TableFixture) =
             Serialized = rand(), guid() ; Serialized2 = { NV = guid() ; NE = enum<Enum> (int (rand()) % 3) } ;
         }
 
-    let table = fixture.CreateContextAndTableIfNotExists<UpdateExprRecord>()
+    let table = fixture.CreateEmpty<UpdateExprRecord>()
 
     let [<Fact>] ``Attempt to update HashKey`` () =
         let item = mkItem()

--- a/tests/FSharp.AWS.DynamoDB.Tests/UpdateExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/UpdateExpressionTests.fs
@@ -94,7 +94,7 @@ type ``Update Expression Tests``(fixture : TableFixture) =
             Serialized = rand(), guid() ; Serialized2 = { NV = guid() ; NE = enum<Enum> (int (rand()) % 3) } ;
         }
 
-    let table = TableContext.Create<UpdateExprRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+    let table = fixture.CreateContextAndTableIfNotExists<UpdateExprRecord>()
 
     let [<Fact>] ``Attempt to update HashKey`` () =
         let item = mkItem()

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -5,12 +5,12 @@ open System.IO
 
 open FsCheck
 open Swensen.Unquote
+open Xunit
 
 open FSharp.AWS.DynamoDB
 
 open Amazon.DynamoDBv2
 open Amazon.Runtime
-open Xunit
 
 [<AutoOpen>]
 module Utils =
@@ -47,7 +47,7 @@ module Utils =
         member _.TableName = tableName
 
         member _.CreateContextAndTableIfNotExists<'TRecord>() =
-            let throughput = Model.ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
+            let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
             Scripting.TableContext.Initialize<'TRecord>(client, tableName, Throughput.Provisioned throughput)
 
         interface IAsyncLifetime with

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -45,7 +45,7 @@ module Utils =
         member _.TableName = tableName
 
         member __.CreateContextAndTableIfNotExists<'TRecord>() =
-            let autoCreate = InitializationMode.CreateIfNotExists (ProvisionedThroughput(10, 10))
+            let autoCreate = InitializationMode.CreateIfNotExists (ProvisionedThroughput(10L, 10L))
             Scripting.TableContext.Initialize<'TRecord>(__.Client, __.TableName, mode = autoCreate)
 
         interface IAsyncLifetime with

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -46,7 +46,7 @@ module Utils =
         member _.Client = client
         member _.TableName = tableName
 
-        member _.CreateContextAndTableIfNotExists<'TRecord>() =
+        member _.CreateEmpty<'TRecord>() =
             let throughput = ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
             Scripting.TableContext.Initialize<'TRecord>(client, tableName, Throughput.Provisioned throughput)
 

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -15,10 +15,10 @@ open Xunit
 [<AutoOpen>]
 module Utils =
 
-    let getRandomTableName() =
-        sprintf "fsdynamodb-%s" <| Guid.NewGuid().ToString("N")
+    let guid () = Guid.NewGuid().ToString("N")
 
-    let guid() = Guid.NewGuid().ToString("N")
+    let getRandomTableName() =
+        sprintf "fsdynamodb-%s" <| guid ()
 
     let shouldFailwith<'T, 'Exn when 'Exn :> exn>(f : unit -> 'T) =
         <@ f () |>  ignore @>
@@ -26,8 +26,8 @@ module Utils =
 
     let getDynamoDBAccount () =
         let credentials = BasicAWSCredentials("Fake", "Fake")
-        let config = AmazonDynamoDBConfig()
-        config.ServiceURL <- "http://localhost:8000"
+        let config = AmazonDynamoDBConfig(ServiceURL = "http://localhost:8000")
+
         new AmazonDynamoDBClient(credentials, config) :> IAmazonDynamoDB
 
 
@@ -39,11 +39,11 @@ module Utils =
 
 
     type TableFixture() =
+
         let client = getDynamoDBAccount()
         let tableName = getRandomTableName()
-        member _.Client = client
-        member _.TableName = tableName
 
+        member _.Client = client
         member _.TableName = tableName
 
         member _.CreateContextAndTableIfNotExists<'TRecord>() =

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -6,6 +6,8 @@ open System.IO
 open FsCheck
 open Swensen.Unquote
 
+open FSharp.AWS.DynamoDB
+
 open Amazon.DynamoDBv2
 open Amazon.Runtime
 open Xunit
@@ -42,9 +44,12 @@ module Utils =
         member _.Client = client
         member _.TableName = tableName
 
+        member __.CreateContextAndTableIfNotExists<'TRecord>() =
+            let autoCreate = InitializationMode.CreateIfNotExists (ProvisionedThroughput(10, 10))
+            Scripting.TableContext.Initialize<'TRecord>(__.Client, __.TableName, mode = autoCreate)
+
         interface IAsyncLifetime with
             member _.InitializeAsync() =
                 System.Threading.Tasks.Task.CompletedTask
             member _.DisposeAsync() =
                 client.DeleteTableAsync(tableName)
-

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -45,8 +45,8 @@ module Utils =
         member _.TableName = tableName
 
         member _.CreateContextAndTableIfNotExists<'TRecord>() =
-            let createThroughput = ProvisionedThroughput(10L, 10L)
-            Scripting.TableContext.Initialize<'TRecord>(client, tableName, createThroughput)
+            let throughput = Model.ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
+            Scripting.TableContext.Initialize<'TRecord>(client, tableName, Provisioned throughput)
 
         interface IAsyncLifetime with
             member _.InitializeAsync() =

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -44,6 +44,8 @@ module Utils =
         member _.Client = client
         member _.TableName = tableName
 
+        member _.TableName = tableName
+
         member _.CreateContextAndTableIfNotExists<'TRecord>() =
             let throughput = Model.ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
             Scripting.TableContext.Initialize<'TRecord>(client, tableName, Throughput.Provisioned throughput)

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -44,9 +44,9 @@ module Utils =
         member _.Client = client
         member _.TableName = tableName
 
-        member __.CreateContextAndTableIfNotExists<'TRecord>() =
-            let autoCreate = InitializationMode.CreateIfNotExists (ProvisionedThroughput(10L, 10L))
-            Scripting.TableContext.Initialize<'TRecord>(__.Client, __.TableName, mode = autoCreate)
+        member _.CreateContextAndTableIfNotExists<'TRecord>() =
+            let createThroughput = ProvisionedThroughput(10L, 10L)
+            Scripting.TableContext.Initialize<'TRecord>(client, tableName, createThroughput)
 
         interface IAsyncLifetime with
             member _.InitializeAsync() =

--- a/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Utils.fs
@@ -46,7 +46,7 @@ module Utils =
 
         member _.CreateContextAndTableIfNotExists<'TRecord>() =
             let throughput = Model.ProvisionedThroughput(readCapacityUnits = 10L, writeCapacityUnits = 10L)
-            Scripting.TableContext.Initialize<'TRecord>(client, tableName, Provisioned throughput)
+            Scripting.TableContext.Initialize<'TRecord>(client, tableName, Throughput.Provisioned throughput)
 
         interface IAsyncLifetime with
             member _.InitializeAsync() =

--- a/tests/FSharp.AWS.DynamoDB.Tests/packages.config
+++ b/tests/FSharp.AWS.DynamoDB.Tests/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Expecto.VisualStudio.TestAdapter" version="6.0.1" targetFramework="net461" developmentDependency="true" />
-</packages>


### PR DESCRIPTION
Replaces `TableContext.Create` and associated APIs with a clearer set of APIs that facilitate better separation of what I see as multiple phases of processing, depending on how one deploys one's app (informed by how Equinox's tooling and conventions separates this in larger applications).

The split is:

0. Being able to create a `TableContext` with the assumption that the underlying table and requisite indexes are in place (without any external calls), via the constructor
1. `VerifyTableAsync` to check that the `tableName` specified by the constructor is in place and has the correct indices in place (`Scripting.Initialize` combines this step with the constructor for scripting scenarios). Does not create a table; throws if there is a problem. Should ideally only be called once per process startup.
2. `VerifyOrCreateTableAsync` - as per `VerifyTableAsync` but will create the table if it happens not to be present. For small single EXE apps, or test scenarios, calling this once on startup may make sense. Can also be used from separated configuration logic; useful for any application scenario where the creation of tables is something that is managed via a configuration phase of a deployment strategy (DDL vs DML separation in SQL DB tech parlance)
3. `UpdateTableIfRequiredAsync` - can apply adjustments to Provisioning or Streaming configuration via the `UpdateTable` API if the table's configuration is not as specified. Used to implement Equinox's CLI tooling wrt establishing and/or changing throughput an/or streaming configuration. 

resolves #35