### PR TITLE
Reverted metricsCollector back to `TableContext` level (rather than per-operation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,7 +209,7 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 
-.fake/*
+.fake
 .paket/paket.exe
 temp/*
 paket-files/*

--- a/.gitignore
+++ b/.gitignore
@@ -211,8 +211,8 @@ ModelManifest.xml
 
 .fake
 .paket/paket.exe
-temp/*
-paket-files/*
+temp
+paket-files
 xunit.html
 /db
 .DS_Store

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -446,7 +446,7 @@ type TableContext<'TRecord> internal
     /// </summary>
     /// <param name="key">Key of item to be fetched.</param>
     /// <param name="projection">Projection expression to be applied to item.</param>
-    member __.GetItemProjectedAsync(key : TableKey, projection : ProjectionExpression<'TRecord, 'TProjection>, ?collector) : Async<'TProjection> = async {
+    member __.GetItemProjectedAsync(key : TableKey, projection : ProjectionExpression<'TRecord, 'TProjection>) : Async<'TProjection> = async {
         let! item = getItemAsync key (Some projection.ProjectionExpr)
         return projection.UnPickle item
     }

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -326,11 +326,11 @@ type TableContext<'TRecord> internal
         let! response = client.BatchWriteItemAsync(pbr, ct) |> Async.AwaitTaskCorrect
         let unprocessed =
             match response.UnprocessedItems.TryGetValue tableName with
-                | (true, reqs) ->
-                    reqs |> Seq.choose (fun r -> r.PutRequest |> Option.ofObj)
-                         |> Seq.map (fun w -> w.Item)
-                         |> Seq.toArray
-                | (false, _) -> [||]
+            | (true, reqs) ->
+                reqs |> Seq.choose (fun r -> r.PutRequest |> Option.ofObj)
+                        |> Seq.map (fun w -> w.Item)
+                        |> Seq.toArray
+            | (false, _) -> [||]
         maybeReport |> Option.iter (fun r -> r BatchWriteItems (Seq.toList response.ConsumedCapacity) (items.Length - unprocessed.Length))
         if response.HttpStatusCode <> HttpStatusCode.OK then
             failwithf "BatchWriteItem put request returned error %O" response.HttpStatusCode
@@ -554,11 +554,11 @@ type TableContext<'TRecord> internal
         let! response = client.BatchWriteItemAsync(request, ct) |> Async.AwaitTaskCorrect
         let unprocessed =
             match response.UnprocessedItems.TryGetValue tableName with
-                | (true, reqs) ->
-                    reqs |> Seq.choose (fun r -> r.DeleteRequest |> Option.ofObj)
-                         |> Seq.map (fun d -> d.Key)
-                         |> Seq.toArray
-                | (false, _) -> [||]
+            | (true, reqs) ->
+                reqs |> Seq.choose (fun r -> r.DeleteRequest |> Option.ofObj)
+                        |> Seq.map (fun d -> d.Key)
+                        |> Seq.toArray
+            | (false, _) -> [||]
         maybeReport |> Option.iter (fun r -> r BatchWriteItems (Seq.toList response.ConsumedCapacity) (keys.Length - unprocessed.Length))
         if response.HttpStatusCode <> HttpStatusCode.OK then
             failwithf "BatchWriteItem deletion request returned error %O" response.HttpStatusCode

--- a/src/FSharp.AWS.DynamoDB/Utils/DynamoUtils.fs
+++ b/src/FSharp.AWS.DynamoDB/Utils/DynamoUtils.fs
@@ -129,21 +129,3 @@ let isValidFieldName (name : string) =
 
 let isValidKeyName (name : string) =
     name <> null && name.Length > 0 && utf8Length name <= 255
-
-let unprocessedDeleteAttributeValues tableName (response : BatchWriteItemResponse) =
-    let (ok, reqs) = response.UnprocessedItems.TryGetValue tableName
-    if ok then
-        reqs |> Seq.choose (fun r -> r.DeleteRequest |> Option.ofObj)
-             |> Seq.map (fun d -> d.Key)
-             |> Seq.toArray
-    else
-        [||]
-
-let unprocessedPutAttributeValues tableName (response : BatchWriteItemResponse) =
-    let (ok, reqs) = response.UnprocessedItems.TryGetValue tableName
-    if ok then
-        reqs |> Seq.choose (fun r -> r.PutRequest |> Option.ofObj)
-             |> Seq.map (fun w -> w.Item)
-             |> Seq.toArray
-    else
-        [||]

--- a/tests/FSharp.AWS.DynamoDB.Tests/FSharp.AWS.DynamoDB.Tests.fsproj
+++ b/tests/FSharp.AWS.DynamoDB.Tests/FSharp.AWS.DynamoDB.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="ProjectionExpressionTests.fs" />
     <Compile Include="SparseGSITests.fs" />
     <Compile Include="PaginationTests.fs" />
+    <Compile Include="MetricsCollectorTests.fs" />
     <Compile Include="Program.fs" />
     <None Include="paket.references" />
     <Content Include="App.config" />

--- a/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
@@ -1,0 +1,174 @@
+namespace FSharp.AWS.DynamoDB.Tests
+
+open System
+
+open Expecto
+
+open FSharp.AWS.DynamoDB
+open FSharp.AWS.DynamoDB.Scripting
+
+[<AutoOpen>]
+module MetricsCollectorTests =
+
+    type MetricsRecord =
+        {
+            [<HashKey>]
+            HashKey : string
+            [<RangeKey>]
+            RangeKey : int
+
+            [<LocalSecondaryIndex>]
+            LocalSecondaryRangeKey : string
+
+            [<GlobalSecondaryHashKey("GSI")>]
+            SecondaryHashKey : string
+            [<GlobalSecondaryRangeKey("GSI")>]
+            SecondaryRangeKey : int
+
+            LocalAttribute : int
+        }
+
+type TestCollector() =
+    let mutable (metrics : RequestMetrics list) = []
+    member _.Collect (m : RequestMetrics) =
+        metrics <- List.append metrics [ m ]
+
+    member _.Metrics with get() = metrics
+
+type ``Metrics Collector Tests`` (fixture : TableFixture) =
+
+    let rand = let r = Random() in fun () -> int64 <| r.Next()
+    let mkItem (hk : string) (gshk : string) (i : int): MetricsRecord =
+        {
+            HashKey = hk
+            RangeKey = i
+            LocalSecondaryRangeKey = guid()
+            SecondaryHashKey = gshk
+            SecondaryRangeKey = i
+            LocalAttribute = int (rand () % 2L)
+        }
+
+    let table = TableContext.Create<MetricsRecord>(fixture.Client, fixture.TableName, createIfNotExists = true)
+
+    member __.``Collect Metrics on GetItem`` () =
+        let item = mkItem (guid()) (guid()) 0
+        table.PutItem item |> ignore
+
+        let collector = TestCollector()
+        let _ = table.WithMetricsCollector(collector.Collect).GetItem (key = TableKey.Combined (item.HashKey, 0))
+        Expect.equal collector.Metrics.Length 1 ""
+        let metrics = collector.Metrics.Head
+        Expect.equal metrics.Operation GetItem ""
+        Expect.equal metrics.TableName fixture.TableName ""
+        Expect.equal metrics.ItemCount 1 ""
+        Expect.isGreaterThan (metrics.ConsumedCapacity |> Seq.sumBy (fun c -> c.CapacityUnits)) 0. ""
+
+    member __.``Collect Metrics on PutItem`` () =
+        let item = mkItem (guid()) (guid()) 0
+        let collector = TestCollector()
+        table.WithMetricsCollector(collector.Collect).PutItem item |> ignore
+
+        Expect.equal collector.Metrics.Length 1 ""
+        let metrics = collector.Metrics.Head
+        Expect.equal metrics.Operation PutItem ""
+        Expect.equal metrics.TableName fixture.TableName ""
+        Expect.equal metrics.ItemCount 1 ""
+        Expect.isGreaterThan (metrics.ConsumedCapacity |> Seq.sumBy (fun c -> c.CapacityUnits)) 0. ""
+
+    member __.``Collect Metrics on UpdateItem`` () =
+        let item = mkItem (guid()) (guid()) 0
+        let collector = TestCollector()
+        table.PutItem item |> ignore
+        table.WithMetricsCollector(collector.Collect).UpdateItem(TableKey.Combined (item.HashKey, item.RangeKey), <@ fun (i : MetricsRecord) -> { i with LocalAttribute = 1000 } @>) |> ignore
+
+        Expect.equal collector.Metrics.Length 1 ""
+        let metrics = collector.Metrics.Head
+        Expect.equal metrics.Operation UpdateItem ""
+        Expect.equal metrics.TableName fixture.TableName ""
+        Expect.equal metrics.ItemCount 1 ""
+        Expect.isGreaterThan (metrics.ConsumedCapacity |> Seq.sumBy (fun c -> c.CapacityUnits)) 0. ""
+
+    member __.``Collect Metrics on Scan`` () =
+        let hk = guid()
+        let gsk = guid()
+        let items = seq { for i in 0 .. 1000 -> mkItem hk gsk i } |> Seq.toArray |> Array.sortBy (fun r -> r.RangeKey)
+        for item in items do
+          table.PutItem item |> ignore
+
+        let collector = TestCollector()
+        let items = table.WithMetricsCollector(collector.Collect).Scan()
+
+        Expect.equal collector.Metrics.Length 1 ""
+        let metrics = collector.Metrics.Head
+        Expect.equal metrics.Operation Scan ""
+        Expect.equal metrics.TableName fixture.TableName ""
+        Expect.equal metrics.ItemCount items.Length ""
+        Expect.isGreaterThan (metrics.ConsumedCapacity |> Seq.sumBy (fun c -> c.CapacityUnits)) 0. ""
+
+    member __.``Collect Metrics on Query`` () =
+        let hk = guid()
+        let gsk = guid()
+        let items = seq { for i in 0 .. 1000 -> mkItem hk gsk i } |> Seq.toArray |> Array.sortBy (fun r -> r.RangeKey)
+        for item in items do
+          table.PutItem item |> ignore
+
+        let collector = TestCollector()
+        let items = table.WithMetricsCollector(collector.Collect).Query(<@ fun (r : MetricsRecord) -> r.HashKey = hk @>)
+
+        Expect.equal collector.Metrics.Length 1 ""
+        let metrics = collector.Metrics.Head
+        Expect.equal metrics.Operation Query ""
+        Expect.equal metrics.TableName fixture.TableName ""
+        Expect.equal metrics.ItemCount items.Length ""
+        Expect.isGreaterThan (metrics.ConsumedCapacity |> Seq.sumBy (fun c -> c.CapacityUnits)) 0. ""
+
+    member __.``Collect Metrics on BatchGetItem`` () =
+        let hk = guid()
+        let gsk = guid()
+        let items = seq { for i in 0 .. 99 -> mkItem hk gsk i } |> Seq.toArray |> Array.sortBy (fun r -> r.RangeKey)
+        for item in items do
+          table.PutItem item |> ignore
+
+        let collector = TestCollector()
+        let items = table.WithMetricsCollector(collector.Collect).BatchGetItems (seq { for i in 0 .. 99 -> TableKey.Combined (hk, i) })
+
+        Expect.equal collector.Metrics.Length 1 ""
+        let metrics = collector.Metrics.Head
+        Expect.equal metrics.Operation BatchGetItems ""
+        Expect.equal metrics.TableName fixture.TableName ""
+        Expect.equal metrics.ItemCount items.Length ""
+        Expect.isGreaterThan (metrics.ConsumedCapacity |> Seq.sumBy (fun c -> c.CapacityUnits)) 0. ""
+
+    member __.``Collect Metrics on BatchPutItem`` () =
+        let hk = guid()
+        let gsk = guid()
+        let items = seq { for i in 0 .. 24 -> mkItem hk gsk i } |> Seq.toArray |> Array.sortBy (fun r -> r.RangeKey)
+        for item in items do
+          table.PutItem item |> ignore
+
+        let collector = TestCollector()
+        table.WithMetricsCollector(collector.Collect).BatchPutItems (items |> Seq.map (fun i -> { i with LocalAttribute = 1000 })) |> ignore
+
+        Expect.equal collector.Metrics.Length 1 ""
+        let metrics = collector.Metrics.Head
+        Expect.equal metrics.Operation BatchWriteItems ""
+        Expect.equal metrics.TableName fixture.TableName ""
+        Expect.equal metrics.ItemCount items.Length ""
+        Expect.isGreaterThan (metrics.ConsumedCapacity |> Seq.sumBy (fun c -> c.CapacityUnits)) 0. ""
+
+    member __.``Collect Metrics on BatchDeleteItem`` () =
+        let hk = guid()
+        let gsk = guid()
+        let items = seq { for i in 0 .. 24 -> mkItem hk gsk i } |> Seq.toArray |> Array.sortBy (fun r -> r.RangeKey)
+        for item in items do
+          table.PutItem item |> ignore
+
+        let collector = TestCollector()
+        table.WithMetricsCollector(collector.Collect).BatchDeleteItems (items |> Seq.map (fun i -> TableKey.Combined (i.HashKey, i.RangeKey))) |> ignore
+
+        Expect.equal collector.Metrics.Length 1 ""
+        let metrics = collector.Metrics.Head
+        Expect.equal metrics.Operation BatchWriteItems ""
+        Expect.equal metrics.TableName fixture.TableName ""
+        Expect.equal metrics.ItemCount items.Length ""
+        Expect.isGreaterThan (metrics.ConsumedCapacity |> Seq.sumBy (fun c -> c.CapacityUnits)) 0. ""

--- a/tests/FSharp.AWS.DynamoDB.Tests/Program.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Program.fs
@@ -212,17 +212,33 @@ let PaginationTests =
             testCase "Paginated Query with filter" paginationTests.``Paginated Query with filter``
         ]
 
+let metricsCollectorTestsTableFixture = new TableFixture()
+let metricsCollectorTests = ``Metrics Collector Tests``(metricsCollectorTestsTableFixture)
+let MetricsCollectorTests =
+    testList "MetricsCollectorTests"
+        [
+            testCase "Collect Metrics on GetItem" metricsCollectorTests.``Collect Metrics on GetItem``
+            testCase "Collect Metrics on PutItem" metricsCollectorTests.``Collect Metrics on PutItem``
+            testCase "Collect Metrics on UpdateItem" metricsCollectorTests.``Collect Metrics on UpdateItem``
+            testCase "Collect Metrics on Scan" metricsCollectorTests.``Collect Metrics on Scan``
+            testCase "Collect Metrics on Query" metricsCollectorTests.``Collect Metrics on Query``
+            testCase "Collect Metrics on BatchGetItem" metricsCollectorTests.``Collect Metrics on BatchGetItem``
+            testCase "Collect Metrics on BatchPutItem" metricsCollectorTests.``Collect Metrics on BatchPutItem``
+            testCase "Collect Metrics on BatchDeleteItem" metricsCollectorTests.``Collect Metrics on BatchDeleteItem``
+        ]
+
 [<Tests>]
 let tests =
     testList ""
         [
-            RecordGenerationTests
-            SimpleTableOperationTests
-            ConditionalExpressionTests
-            UpdateExpressionTests
-            ProjectionExpressionTests
-            SparseGSITests
-            PaginationTests
+            // RecordGenerationTests
+            // SimpleTableOperationTests
+            // ConditionalExpressionTests
+            // UpdateExpressionTests
+            // ProjectionExpressionTests
+            // SparseGSITests
+            // PaginationTests
+            MetricsCollectorTests
         ]
 
 [<EntryPoint>]

--- a/tests/FSharp.AWS.DynamoDB.Tests/Program.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Program.fs
@@ -231,13 +231,13 @@ let MetricsCollectorTests =
 let tests =
     testList ""
         [
-            // RecordGenerationTests
-            // SimpleTableOperationTests
-            // ConditionalExpressionTests
-            // UpdateExpressionTests
-            // ProjectionExpressionTests
-            // SparseGSITests
-            // PaginationTests
+            RecordGenerationTests
+            SimpleTableOperationTests
+            ConditionalExpressionTests
+            UpdateExpressionTests
+            ProjectionExpressionTests
+            SparseGSITests
+            PaginationTests
             MetricsCollectorTests
         ]
 

--- a/tests/FSharp.AWS.DynamoDB.Tests/Program.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/Program.fs
@@ -56,6 +56,7 @@ let SimpleTableOperationTests =
             testCase "Convert to compatible table 2" simpleTableOperationTests.``Convert to compatible table 2``
             testCase "Simple Put Operation" simpleTableOperationTests.``Simple Put Operation``
             testCase "ContainsKey Operation" simpleTableOperationTests.``ContainsKey Operation``
+            testCase "TryGet Operation" simpleTableOperationTests.``TryGet Operation``
             testCase "Batch Put Operation" simpleTableOperationTests.``Batch Put Operation``
             testCase "Batch Delete Operation" simpleTableOperationTests.``Batch Delete Operation``
             testCase "Simple Delete Operation" simpleTableOperationTests.``Simple Delete Operation``
@@ -218,8 +219,10 @@ let MetricsCollectorTests =
     testList "MetricsCollectorTests"
         [
             testCase "Collect Metrics on GetItem" metricsCollectorTests.``Collect Metrics on GetItem``
+            testCase "Collect Metrics on ContainsKey" metricsCollectorTests.``Collect Metrics on ContainsKey``
             testCase "Collect Metrics on PutItem" metricsCollectorTests.``Collect Metrics on PutItem``
             testCase "Collect Metrics on UpdateItem" metricsCollectorTests.``Collect Metrics on UpdateItem``
+            testCase "Collect Metrics on DeleteItem" metricsCollectorTests.``Collect Metrics on DeleteItem``
             testCase "Collect Metrics on Scan" metricsCollectorTests.``Collect Metrics on Scan``
             testCase "Collect Metrics on Query" metricsCollectorTests.``Collect Metrics on Query``
             testCase "Collect Metrics on BatchGetItem" metricsCollectorTests.``Collect Metrics on BatchGetItem``


### PR DESCRIPTION
Also includes:

* `WithMetricsCollector()` copy method for `TableContext`
* Basic unit tests
* A couple of fixes to metrics item counts