### PR TITLE
Add TransactWriteItems

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 0.11.0-beta
+* Added `Precondition.CheckFailed`
+* Added `TableContext.TransactWriteItems`, `TransactWrite` DU, `TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed`
+
 ### 0.10.1-beta
 * Fixed accidentally removed/renamed legacy factory methods (`TableContext.Create`/`TableContext.CreateAsync`) 
 

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -780,10 +780,12 @@ type TableContext<'TRecord> internal
     ///     See the DynamoDB <a href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html"><c>TransactWriteItems</c> API documentation</a> for full details of semantics and charges.<br/>
     /// </summary>
     /// <param name="items">Operations to be performed.<br/>
+    /// Throws <c>ArgumentOutOfRangeException</c> if item count is not between 1 and 25 as required by underlying API.<br/>
     /// Use <c>TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed</c> to identify any Precondition Check failures.</param>
     /// <param name="clientRequestToken">The <c>ClientRequestToken</c> to supply as an idempotency key (10 minute window).</param>
     member _.TransactWriteItems(items : seq<TransactWrite<'TRecord>>, ?clientRequestToken) : Async<unit> = async {
         let reqs = TransactWriteItemsRequest.toTransactItems tableName template items
+        if reqs.Count = 0 || reqs.Count > 25 then raise <| System.ArgumentOutOfRangeException(nameof items, "must be between 1 and 25 items.")
         let req = TransactWriteItemsRequest(ReturnConsumedCapacity = returnConsumedCapacity, TransactItems = reqs)
         clientRequestToken |> Option.iter (fun x -> req.ClientRequestToken <- x)
         let! ct = Async.CancellationToken

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -183,7 +183,7 @@ module internal Provisioning =
         run (client, tableName, template) None
 
 /// Represents the operation performed on the table, for metrics collection purposes
-type Operation = GetItem | PutItem | UpdateItem | DeleteItem | BatchGetItems | BatchWriteItems | Scan | Query
+type Operation = GetItem | PutItem | UpdateItem | DeleteItem | BatchGetItems | BatchWriteItems | TransactWriteItems | Scan | Query
 
 /// Represents metrics returned by the table operation, for plugging in to an observability framework
 type RequestMetrics =
@@ -208,6 +208,57 @@ type private LimitType =
         | Default -> false
     static member AllOrCount (l : int option) = l |> Option.map Count |> Option.defaultValue All
     static member DefaultOrCount (l : int option) = l |> Option.map Count |> Option.defaultValue Default
+
+/// <summary>Represents an individual request that can be included in the <c>TransactItems</c> of a <c>TransactWriteItems</c> call.</summary>
+[<RequireQualifiedAccess>]
+type TransactWrite<'TRecord> =
+    /// Specify a Check to be run on a specified item.
+    /// If the condition does not hold, the overall TransactWriteItems request will be Canceled.
+    | Check  of key : TableKey  * condition : ConditionExpression<'TRecord>
+    /// Specify a PutItem operation to be performed, inserting or replacing an item in the Table.
+    /// If the (optional) precondition does not hold, the overall TransactWriteItems request will be Canceled.
+    | Put    of item : 'TRecord * precondition : ConditionExpression<'TRecord> option
+    /// Specify an UpdateItem operation to be performed, applying an updater expression on the item identified by the specified `key`, if it exists.
+    /// If the item exists and the (optional) precondition does not hold, the overall TransactWriteItems request will be Canceled.
+    | Update of key : TableKey  * precondition : ConditionExpression<'TRecord> option   * updater : UpdateExpression<'TRecord>
+    /// Specify a DeleteItem operation to be performed, removing the item identified by the specified `key` if it exists.
+    /// If the item exists and the (optional) precondition does not hold, the overall TransactWriteItems request will be Canceled.
+    | Delete of key : TableKey  * precondition : ConditionExpression<'TRecord> option
+
+/// Helpers for building a <c>TransactWriteItemsRequest</c> to supply to <c>TransactWriteItems</c>
+module TransactWriteItemsRequest =
+
+    let private toTransactWriteItem<'TRecord> tableName (template : RecordTemplate<'TRecord>) : TransactWrite<'TRecord> -> TransactWriteItem = function
+        | TransactWrite.Check (key, cond) ->
+            let req = ConditionCheck(TableName = tableName, Key = template.ToAttributeValues key)
+            let writer = AttributeWriter(req.ExpressionAttributeNames, req.ExpressionAttributeValues)
+            req.ConditionExpression <- cond.Conditional.Write writer
+            TransactWriteItem(ConditionCheck = req)
+        | TransactWrite.Put (item, maybeCond) ->
+            let req = Put(TableName = tableName, Item = template.ToAttributeValues item)
+            maybeCond |> Option.iter (fun cond ->
+                let writer = AttributeWriter(req.ExpressionAttributeNames, req.ExpressionAttributeValues)
+                req.ConditionExpression <- cond.Conditional.Write writer)
+            TransactWriteItem(Put = req)
+        | TransactWrite.Update (key, maybeCond, updater) ->
+            let req = Update(TableName = tableName, Key = template.ToAttributeValues key)
+            let writer = AttributeWriter(req.ExpressionAttributeNames, req.ExpressionAttributeValues)
+            req.UpdateExpression <- updater.UpdateOps.Write(writer)
+            maybeCond |> Option.iter (fun cond -> req.ConditionExpression <- cond.Conditional.Write writer)
+            TransactWriteItem(Update = req)
+        | TransactWrite.Delete (key, maybeCond) ->
+            let req = Delete(TableName = tableName, Key = template.ToAttributeValues key)
+            maybeCond |> Option.iter (fun cond ->
+                let writer = AttributeWriter(req.ExpressionAttributeNames, req.ExpressionAttributeValues)
+                req.ConditionExpression <- cond.Conditional.Write writer)
+            TransactWriteItem(Delete = req)
+    let internal toTransactItems<'TRecord> tableName template items = Seq.map (toTransactWriteItem<'TRecord> tableName template) items |> rlist
+
+    /// <summary>Exception filter to identify whether a <c>TransactWriteItems</c> call has failed due to
+    /// one or more of the supplied <c>precondition</c> checks failing.</summary>
+    let (|TransactionCanceledConditionalCheckFailed|_|) : exn -> unit option = function
+        | :? TransactionCanceledException as e when e.CancellationReasons.Exists(fun x -> x.Code = "ConditionalCheckFailed") -> Some ()
+        | _ -> None
 
 /// DynamoDB client object for performing table operations in the context of given F# record representations
 [<Sealed; AutoSerializable(false)>]
@@ -720,6 +771,26 @@ type TableContext<'TRecord> internal
             failwithf "BatchWriteItem deletion request returned error %O" response.HttpStatusCode
 
         return unprocessed |> Array.map template.ExtractKey
+    }
+
+
+    /// <summary>
+    ///     Atomically applies a set of 1-25 write operations to the table.<br/>
+    ///     NOTE requests are charged at twice the normal rate in Write Capacity Units.
+    ///     See the DynamoDB <a href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html"><c>TransactWriteItems</c> API documentation</a> for full details of semantics and charges.<br/>
+    /// </summary>
+    /// <param name="items">Operations to be performed.<br/>
+    /// Use <c>TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed</c> to identify any Precondition Check failures.</param>
+    /// <param name="clientRequestToken">The <c>ClientRequestToken</c> to supply as an idempotency key (10 minute window).</param>
+    member _.TransactWriteItems(items : seq<TransactWrite<'TRecord>>, ?clientRequestToken) : Async<unit> = async {
+        let reqs = TransactWriteItemsRequest.toTransactItems tableName template items
+        let req = TransactWriteItemsRequest(ReturnConsumedCapacity = returnConsumedCapacity, TransactItems = reqs)
+        clientRequestToken |> Option.iter (fun x -> req.ClientRequestToken <- x)
+        let! ct = Async.CancellationToken
+        let! response = client.TransactWriteItemsAsync(req, ct) |> Async.AwaitTaskCorrect
+        maybeReport |> Option.iter (fun r -> r TransactWriteItems (Seq.toList response.ConsumedCapacity) reqs.Count)
+        if response.HttpStatusCode <> HttpStatusCode.OK then
+            failwithf "TransactWriteItems request returned error %O" response.HttpStatusCode
     }
 
 

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -2,6 +2,7 @@
 
 open System
 
+open FSharp.AWS.DynamoDB.Tests
 open Swensen.Unquote
 open Xunit
 
@@ -125,22 +126,106 @@ type ``Simple Table Operation Tests`` (fixture : TableFixture) =
         test <@ None = deletedItem @>
         test <@ not (table.ContainsKey key) @>
 
+    interface IClassFixture<TableFixture>
+
+type TransactWriteItems(fixture : TableFixture) =
+
+    let rand = let r = Random() in fun () -> int64 <| r.Next()
+    let mkItem() =
+        {
+            HashKey = guid() ; RangeKey = guid() ;
+            Value = rand() ; Tuple = rand(), rand() ;
+            Map = seq { for _ in 0L .. rand() % 5L -> "K" + guid(), rand() } |> Map.ofSeq
+            Unions = [Choice1Of3 (guid()) ; Choice2Of3(rand()) ; Choice3Of3(Guid.NewGuid().ToByteArray())]
+        }
+
+    let table = fixture.CreateEmpty<SimpleRecord>()
+    let compile = table.Template.PrecomputeConditionalExpr
+    let compileUpdate (e : Quotations.Expr<SimpleRecord -> SimpleRecord>) = table.Template.PrecomputeUpdateExpr e
+    let doesntExistCondition = compile <@ fun t -> NOT_EXISTS t.Value @>
+    let existsCondition = compile <@ fun t -> EXISTS t.Value @>
+
+    let [<Fact>] ``Minimal happy path`` () = async {
+        let item = mkItem ()
+
+        let requests = [TransactWrite.Put (item, Some doesntExistCondition) ]
+
+        do! table.TransactWriteItems requests
+
+        let! itemFound = table.ContainsKeyAsync (table.Template.ExtractKey item)
+        true =! itemFound }
+
+    let [<Fact>] ``Minimal Canceled path`` () = async {
+        let item = mkItem ()
+
+        let requests = [TransactWrite.Put (item, Some existsCondition) ]
+
+        let mutable failed = false
+        try do! table.TransactWriteItems requests
+        with TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed -> failed <- true
+
+        true =! failed
+
+        let! itemFound = table.ContainsKeyAsync (table.Template.ExtractKey item)
+        false =! itemFound }
+
     let [<Theory; InlineData true; InlineData false>]
-        ``Condition Check outcome should affect sibling TransactWrite`` shouldFail = async {
+        ``ConditionCheck outcome should affect sibling TransactWrite`` shouldFail = async {
         let item, item2 = mkItem (), mkItem ()
-        let key = table.PutItem item
+        let! key = table.PutItemAsync item
 
         let requests = [
-            if shouldFail then  TransactWrite.Check (key, table.Template.PrecomputeConditionalExpr <@ fun t -> NOT_EXISTS t.Value @>)
-            else                TransactWrite.Check (key, table.Template.PrecomputeConditionalExpr <@ fun t -> EXISTS t.Value @>)
+            if shouldFail then  TransactWrite.Check (key, doesntExistCondition)
+            else                TransactWrite.Check (key, existsCondition)
                                 TransactWrite.Put   (item2, None) ]
         let mutable failed = false
         try do! table.TransactWriteItems requests
         with TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed -> failed <- true
 
-        let failed = failed
-        test <@ failed = shouldFail @>
-        let item2Found = table.ContainsKey (table.Template.ExtractKey item2)
-        test <@ not shouldFail = item2Found @> }
+        failed =! shouldFail
+
+        let! item2Found = table.ContainsKeyAsync (table.Template.ExtractKey item2)
+        failed =! not item2Found }
+
+    let [<Theory; InlineData true; InlineData false>]
+        ``All paths`` shouldFail = async {
+        let item, item2, item3, item4, item5, item6, item7 = mkItem (), mkItem (), mkItem (), mkItem (), mkItem (), mkItem (), mkItem ()
+        let! key = table.PutItemAsync item
+
+        let requests = [ TransactWrite.Update (key, Some existsCondition, compileUpdate <@ fun t -> { t with Value = 42 } @>)
+                         TransactWrite.Put    (item2, None)
+                         TransactWrite.Put    (item3, Some doesntExistCondition)
+                         TransactWrite.Delete (table.Template.ExtractKey item4, Some doesntExistCondition)
+                         TransactWrite.Delete (table.Template.ExtractKey item5, None)
+                         TransactWrite.Check  (table.Template.ExtractKey item6, if shouldFail then existsCondition else doesntExistCondition)
+                         TransactWrite.Update (TableKey.Combined(item7.HashKey, item7.RangeKey), None, compileUpdate <@ fun t -> { t with Tuple = (42, 42)} @>) ]
+        let mutable failed = false
+        try do! table.TransactWriteItems requests
+        with TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed -> failed <- true
+        failed =! shouldFail
+
+        let! maybeItem = table.TryGetItemAsync key
+        test <@ shouldFail <> (maybeItem |> Option.contains { item with Value = 42 }) @>
+
+        let! maybeItem2 = table.TryGetItemAsync(table.Template.ExtractKey item2)
+        test <@ shouldFail <> (maybeItem2 |> Option.contains item2) @>
+
+        let! maybeItem3 = table.TryGetItemAsync(table.Template.ExtractKey item3)
+        test <@ shouldFail <> (maybeItem3 |> Option.contains item3) @>
+
+        let! maybeItem7 = table.TryGetItemAsync(table.Template.ExtractKey item7)
+        test <@ shouldFail <> (maybeItem7 |> Option.map (fun x -> x.Tuple) |> Option.contains (42, 42)) @> }
+
+    let shouldBeRejectedWithArgumentOutOfRangeException requests = async {
+        let! e = Async.Catch (table.TransactWriteItems requests)
+        test <@ match e with
+                | Choice1Of2 () -> false
+                | Choice2Of2 e -> e :? ArgumentOutOfRangeException @> }
+
+    let [<Fact>] ``Empty request list is rejected with AORE`` () =
+        shouldBeRejectedWithArgumentOutOfRangeException []
+
+    let [<Fact>] ``Over 25 writes are rejected with AORE`` () =
+        shouldBeRejectedWithArgumentOutOfRangeException [for _x in 1..26 -> TransactWrite.Put (mkItem (), None)]
 
     interface IClassFixture<TableFixture>

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -128,7 +128,7 @@ type ``Simple Table Operation Tests`` (fixture : TableFixture) =
 
     interface IClassFixture<TableFixture>
 
-type TransactWriteItems(fixture : TableFixture) =
+type ``TransactWriteItems tests``(fixture : TableFixture) =
 
     let rand = let r = Random() in fun () -> int64 <| r.Next()
     let mkItem() =


### PR DESCRIPTION
- Wraps the [`TransactWriteItems`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html) API
  
  - [x] Basic impl
  - [x] Validate IRL in Equinox https://github.com/jet/equinox/pull/321
  - [x] empty request list or >25 items should be rejected with `ArgumentOutOfRangeException`
      - [ ] arguably all such guards should be made consistent herein?
  - [x] Tests
      - [x] passing/failing `Check` + unconditional `PutItem` pair
      - [x] Cover presence and absence of all conditions and all actions
      - [x] gathering metrics (not available when check fails)
  - [x] README example    

- Adds a `Precondition.CheckFailed` for trapping normal precondition check fails