### PR TITLE
Sync with canonical Async.AwaitTaskCorrect

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 0.11.1-beta
+* Updated internal `AwaitTaskCorrect` implementation to align with [canonical version](http://www.fssnip.net/7Rc/title/AsyncAwaitTaskCorrect) [#49](https://github.com/fsprojects/FSharp.AWS.DynamoDB/pull/49) 
+
 ### 0.11.0-beta
 * Added `Precondition.CheckFailed`
 * Added `TableContext.TransactWriteItems`, `TransactWrite` DU, `TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed`
@@ -16,7 +19,7 @@
 * Obsoleted `TableContext.UpdateProvisionedThroughputAsync` (replace with `TableContext.UpdateTableIfRequiredAsync`)
 * (breaking) Obsoleted `TableContext.VerifyTableAsync` optional argument to create a Table (replace with `VerifyOrCreateTableAsync`)
 * (breaking) Changed `TableKeySchemata.CreateCreateTableRequest` to `ApplyToCreateTableRequest` (with minor signature change)
-* (breaking) Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `VerifyOrCreateTableAsync`)
+* (breaking; reverted in `0.10.1`) Removed `TableContext.CreateAsync` (replace with `TableContext.VerifyTableAsync` or `VerifyOrCreateTableAsync`)
 
 ### 0.9.4-beta
 * Moved Sync-over-Async versions of `TableContext` operations into `namespace FSharp.AWS.DynamoDB.Scripting`

--- a/tests/FSharp.AWS.DynamoDB.Tests/FSharp.AWS.DynamoDB.Tests.fsproj
+++ b/tests/FSharp.AWS.DynamoDB.Tests/FSharp.AWS.DynamoDB.Tests.fsproj
@@ -19,9 +19,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FsCheck" Version="2.16.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
In isolating https://github.com/dotnet/fsharp/issues/13165, the fact that the `AwaitTaskCorrect` impl herein predates the current [fsssnip edition](http://www.fssnip.net/7Rc/title/AsyncAwaitTaskCorrect), and that the `task.InnerException` is subtle led me down additional paths that would be nice to avoid, especially given that ultimately there should be convergence in the implementations via https://github.com/fsharp/fslang-suggestions/issues/840.

- Equinox [already had the canonical edition](https://github.com/jet/equinox/commit/ac3fa327aa8834ae0a580cab359129efff8ea065), which has had lots of road testing
- Similar PR canonicalizing https://github.com/jet/FsKafka/pull/92 ()
- Synced in Propulsion project as that had cloned FsKafka https://github.com/jet/propulsion/commit/3c11142b75bf3b0ef2181fd106a4b17c0b2313ef