### PR TITLE
Fix: Handle null StreamSpecification

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### 0.11.1-beta
 * Updated internal `AwaitTaskCorrect` implementation to align with [canonical version](http://www.fssnip.net/7Rc/title/AsyncAwaitTaskCorrect) [#49](https://github.com/fsprojects/FSharp.AWS.DynamoDB/pull/49) 
 * Added SourceLink info (using `DotNet.ReproducibleBuilds`)
+* Fixed `TableContext.UpdateTableIfRequiredAsync`: Guard against `NullReferenceException` when `StreamSpecification` is `null`
 
 ### 0.11.0-beta
 * Added `Precondition.CheckFailed`

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "6.0.301",
     "rollForward": "latestMajor"
   }
 }

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -64,8 +64,8 @@ module internal Streaming =
     let applyToCreateRequest (req : CreateTableRequest) (Spec spec) =
         req.StreamSpecification <- spec
     let requiresUpdate (desc : TableDescription) = function
-        | Streaming.Disabled -> desc.StreamSpecification.StreamEnabled
-        | Streaming.Enabled svt -> not desc.StreamSpecification.StreamEnabled || desc.StreamSpecification.StreamViewType <> svt
+        | Streaming.Disabled -> match desc.StreamSpecification with null -> false | s -> s.StreamEnabled
+        | Streaming.Enabled svt -> match desc.StreamSpecification with null -> true | s -> not s.StreamEnabled || s.StreamViewType <> svt
     let applyToUpdateRequest (req : UpdateTableRequest) (Spec spec) =
         req.StreamSpecification <- spec
 


### PR DESCRIPTION
Current logic triggers a `NullReferenceException` when Streaming has not been configured