### PR TITLE
Support ADDing numbers

### DIFF
--- a/src/FSharp.AWS.DynamoDB/Expression/UpdateExpr.fs
+++ b/src/FSharp.AWS.DynamoDB/Expression/UpdateExpr.fs
@@ -220,6 +220,11 @@ let extractOpExprUpdaters (recordInfo : RecordTableInfo) (expr : Expr) : Interme
                 attrs.Add attr
                 updateOps.Add (Add (attr.Id, op))
 
+            | SpecificCall2 <@ ADD_INT64 @> (None, _, _, [AttributeGet attr; value]) ->
+                let op = getOperand attr.Pickler value
+                attrs.Add attr
+                updateOps.Add (Add (attr.Id, op))
+
             | SpecificCall2 <@ DELETE @> (None, _, _, [AttributeGet attr; value]) ->
                 let op = getOperand attr.Pickler value
                 attrs.Add attr

--- a/src/FSharp.AWS.DynamoDB/Types.fs
+++ b/src/FSharp.AWS.DynamoDB/Types.fs
@@ -280,6 +280,10 @@ module UpdateOperators =
     let ADD (path : Set<'T>) (values : seq<'T>) : UpdateOp =
         invalidOp "ADD operation reserved for quoted update expressions."
 
+    /// Adds given value to attribute path
+    let ADD_INT64 (path : int64) (value : int64) : UpdateOp =
+        invalidOp "ADD_INT64 operation reserved for quoted update expressions."
+
     /// Deletes given set of values to set attribute path
     let DELETE (path : Set<'T>) (values : seq<'T>) : UpdateOp =
         invalidOp "DELETE operation reserved for quoted update expressions."

--- a/tests/FSharp.AWS.DynamoDB.Tests/UpdateExpressionTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/UpdateExpressionTests.fs
@@ -371,6 +371,27 @@ type ``Update Expression Tests``(fixture : TableFixture) =
 
         test <@ item'.IntSet.Contains 42L @>
 
+    let [<Fact>] ``ADD to int`` () =
+        let item = mkItem()
+        let key = table.PutItem item
+        let item' = table.UpdateItem(key, <@ fun r -> ADD_INT64 r.Value 1L @>)
+
+        test <@ item.Value + 1L = item'.Value @>
+
+
+    let [<Fact>] ``ADD to int without creating item first`` () =
+        let item = mkItem()
+        let item' = table.UpdateItem(TableKey.Combined(item.HashKey, item.RangeKey), <@ fun (r : R) ->
+            ADD_INT64 r.Value 42L &&&
+            // Set attributes to satisfy default values
+            //  System.NotSupportedException : Default value...
+            //    at FSharp.AWS.DynamoDB.Pickler.Pickler`1.get_DefaultValueUntyped()
+            SET r.Union (UA 0L) &&&
+            SET r.Serialized item.Serialized &&&
+            SET r.Serialized2 item.Serialized2 @>)
+
+        test <@ 0L + 42L = item'.Value @>
+
     let [<Fact>]``DELETE from set`` () =
         let item = { mkItem() with IntSet = set [1L ; 42L] }
         let key = table.PutItem item


### PR DESCRIPTION
An [`ADD`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.ADD) in an update expression lets you increment a number attribute which doesn't exist yet, treating it as zero. Trying to use [`SET`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET) to increment a non-existent attribute will throw:
>The provided expression refers to an attribute that does not exist in the item

The current update operations allow `ADD`ing to a set attribute only (`let ADD (path : Set<'T>) (values : seq<'T>)`), this PR proposes adding support to `ADD` to a number attribute.

---

It's in draft right now because I'm looking for guidance on how you want this contribution to be implemented, should you want this contribution. The current changes shown in this PR are just the ~~silliest~~ simplest thing to verify the tests would pass.

Specifically, I'm guessing we don't want various `ADD_*` functions, so I'm thinking of how we could support `ADD`ing numbers without introducing those. Perhaps:

## TODO

- [ ] Change `module UpdateOperators`
   - [ ] to be a `type UpdateOperators` with static operators so `ADD` can be overloaded with the various number types, and
   - [ ] redeclare a `module UpdateOperators` which exposes the the current functions so it's not a breaking change
- [ ] Declare a simpler record instead of working around default value for `UpdateExprRecord`