### PR TITLE
TransactWriteItems: Up limit to 100 items

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 ### 0.11.1-beta
-* Fixed `TransactWriteItems`: removed hard-wired limit of 25 to enable leaning on [increased limit of 100 in service](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/)
+* Fixed `TransactWriteItems`: updated validation to reflect [increased limit of 100 items in service](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/)
 
 ### 0.11.1-beta
 * Updated internal `TypeShape` dependency to 10.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 ### 0.11.1-beta
+* Fixed `TransactWriteItems`: removed hard-wired limit of 25 to enable leaning on [increased limit of 100 in service](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/)
+
+### 0.11.1-beta
 * Updated internal `TypeShape` dependency to 10.0.0
 * Updated internal `AwaitTaskCorrect` implementation to align with [canonical version](http://www.fssnip.net/7Rc/title/AsyncAwaitTaskCorrect) [#49](https://github.com/fsprojects/FSharp.AWS.DynamoDB/pull/49) 
 * Added SourceLink info (using `DotNet.ReproducibleBuilds`)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ framework: net60, netstandard20, netstandard21
 nuget Unquote ~> 6.1.0
 nuget FSharp.Core >= 4.7.2 lowest_matching: true
 
-nuget AWSSDK.DynamoDBv2 ~> 3.7.0
+nuget AWSSDK.DynamoDBv2 ~> 3.7.5
 nuget DotNet.ReproducibleBuilds
 github eiriktsarpalis/TypeShape:10.0.0 src/TypeShape/TypeShape.fs
 

--- a/paket.lock
+++ b/paket.lock
@@ -2,10 +2,10 @@ STORAGE: NONE
 RESTRICTION: || (== net6.0) (== netstandard2.0) (== netstandard2.1)
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    AWSSDK.Core (3.7.10.1)
+    AWSSDK.Core (3.7.13.18)
       Microsoft.Bcl.AsyncInterfaces (>= 1.1) - restriction: || (&& (== net6.0) (< netcoreapp3.1)) (== netstandard2.0) (== netstandard2.1)
-    AWSSDK.DynamoDBv2 (3.7.3.16)
-      AWSSDK.Core (>= 3.7.10.1 < 4.0)
+    AWSSDK.DynamoDBv2 (3.7.5.14)
+      AWSSDK.Core (>= 3.7.13.18 < 4.0)
     DotNet.ReproducibleBuilds (1.1.1)
       Microsoft.SourceLink.AzureRepos.Git (>= 1.1.1)
       Microsoft.SourceLink.Bitbucket.Git (>= 1.1.1)

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -292,7 +292,7 @@ type TableContext<'TRecord> internal
         | Some proj ->
             let aw = AttributeWriter(request.ExpressionAttributeNames, null)
             request.ProjectionExpression <- proj.Write aw
-        
+
         match consistentRead with
         | None -> ()
         | Some c -> request.ConsistentRead <- c
@@ -792,17 +792,17 @@ type TableContext<'TRecord> internal
 
 
     /// <summary>
-    ///     Atomically applies a set of 1-25 write operations to the table.<br/>
+    ///     Atomically applies a set of 1 write operations to the table.<br/>
     ///     NOTE requests are charged at twice the normal rate in Write Capacity Units.
     ///     See the DynamoDB <a href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html"><c>TransactWriteItems</c> API documentation</a> for full details of semantics and charges.<br/>
     /// </summary>
     /// <param name="items">Operations to be performed.<br/>
-    /// Throws <c>ArgumentOutOfRangeException</c> if item count is not between 1 and 25 as required by underlying API.<br/>
+    /// Throws <c>ArgumentOutOfRangeException</c> if item count is less than 1 as required by underlying API.<br/>
     /// Use <c>TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed</c> to identify any Precondition Check failures.</param>
     /// <param name="clientRequestToken">The <c>ClientRequestToken</c> to supply as an idempotency key (10 minute window).</param>
     member _.TransactWriteItems(items : seq<TransactWrite<'TRecord>>, ?clientRequestToken) : Async<unit> = async {
         let reqs = TransactWriteItemsRequest.toTransactItems tableName template items
-        if reqs.Count = 0 || reqs.Count > 25 then raise <| System.ArgumentOutOfRangeException(nameof items, "must be between 1 and 25 items.")
+        if reqs.Count = 0 then raise <| System.ArgumentOutOfRangeException(nameof items, "There must be at least 1 item.")
         let req = TransactWriteItemsRequest(ReturnConsumedCapacity = returnConsumedCapacity, TransactItems = reqs)
         clientRequestToken |> Option.iter (fun x -> req.ClientRequestToken <- x)
         let! ct = Async.CancellationToken

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -792,17 +792,17 @@ type TableContext<'TRecord> internal
 
 
     /// <summary>
-    ///     Atomically applies a set of 1 write operations to the table.<br/>
+    ///     Atomically applies a set of 1-100 write operations to the table.<br/>
     ///     NOTE requests are charged at twice the normal rate in Write Capacity Units.
     ///     See the DynamoDB <a href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html"><c>TransactWriteItems</c> API documentation</a> for full details of semantics and charges.<br/>
     /// </summary>
     /// <param name="items">Operations to be performed.<br/>
-    /// Throws <c>ArgumentOutOfRangeException</c> if item count is less than 1 as required by underlying API.<br/>
+    /// Throws <c>ArgumentOutOfRangeException</c> if item count is not between 1 and 100 as required by underlying API.<br/>
     /// Use <c>TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed</c> to identify any Precondition Check failures.</param>
     /// <param name="clientRequestToken">The <c>ClientRequestToken</c> to supply as an idempotency key (10 minute window).</param>
     member _.TransactWriteItems(items : seq<TransactWrite<'TRecord>>, ?clientRequestToken) : Async<unit> = async {
         let reqs = TransactWriteItemsRequest.toTransactItems tableName template items
-        if reqs.Count = 0 then raise <| System.ArgumentOutOfRangeException(nameof items, "There must be at least 1 item.")
+        if reqs.Count = 0 || reqs.Count > 100 then raise <| System.ArgumentOutOfRangeException(nameof items, "must be between 1 and 100 items.")
         let req = TransactWriteItemsRequest(ReturnConsumedCapacity = returnConsumedCapacity, TransactItems = reqs)
         clientRequestToken |> Option.iter (fun x -> req.ClientRequestToken <- x)
         let! ct = Async.CancellationToken

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -225,4 +225,7 @@ type ``TransactWriteItems tests``(fixture : TableFixture) =
     let [<Fact>] ``Empty request list is rejected with AORE`` () =
         shouldBeRejectedWithArgumentOutOfRangeException []
 
+    let [<Fact>] ``Over 100 writes are rejected with AORE`` () =
+        shouldBeRejectedWithArgumentOutOfRangeException [for _x in 1..101 -> TransactWrite.Put (mkItem (), None)]
+
     interface IClassFixture<TableFixture>

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -225,7 +225,4 @@ type ``TransactWriteItems tests``(fixture : TableFixture) =
     let [<Fact>] ``Empty request list is rejected with AORE`` () =
         shouldBeRejectedWithArgumentOutOfRangeException []
 
-    let [<Fact>] ``Over 25 writes are rejected with AORE`` () =
-        shouldBeRejectedWithArgumentOutOfRangeException [for _x in 1..26 -> TransactWrite.Put (mkItem (), None)]
-
     interface IClassFixture<TableFixture>


### PR DESCRIPTION
- Updated limit of 25 for TransactWriteItems to reflect [lifting of service limit to 100](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction)