### PR TITLE
Prioritise range key check when constructing a key condition from a BeginsWith expression

### DIFF
--- a/src/FSharp.AWS.DynamoDB/Expression/ConditionalExpr.fs
+++ b/src/FSharp.AWS.DynamoDB/Expression/ConditionalExpr.fs
@@ -119,9 +119,9 @@ let extractKeyCondition (qExpr : QueryExpr) =
         | Not _
         | Or _ -> false
         | And(l,r) -> isKeyCond l && isKeyCond r
-        | BeginsWith(attr,_) when attr.IsHashKey -> false
         | BeginsWith(attr,_) when attr.IsRangeKey -> 
             trySet rangeKeyRef attr
+        | BeginsWith(attr,_) when attr.IsHashKey -> false
 
         | BeginsWith _ -> false
         | Between (Attribute attr, (Value _ | Param _), (Value _ | Param _)) when attr.IsRangeKey -> trySet rangeKeyRef attr


### PR DESCRIPTION
Related to https://github.com/fsprojects/FSharp.AWS.DynamoDB/issues/36

Given a record as described in the issue

```
type TableItem =
    { [<HashKey>]
      [<GlobalSecondaryRangeKey(indexName = "Inverted")>]
      PrimaryKey: string
      [<RangeKey>]
      [<GlobalSecondaryHashKey(indexName = "Inverted")>]
      SortKey: string
      Model: Model }
```

A `keyCondition` like this one fails, since both the `IsHashKey` and `IsRangeKey` methods evaluate to true:

```
let tableCtx: TableContext<TableItem> = ...
tableCtx.queryAsync(<@fun tableItem -> tableItem.PrimaryKey = "..." && tableItem.SortKey.StartsWith "..." @>)

// System.ArgumentException: key conditions must satisfy the following constraints:
// * Must only reference HashKey & RangeKey attributes.
// * Must reference HashKey attribute exactly once.
// * Must reference RangeKey attribute at most once.
// * HashKey comparison must be equality comparison only.
// * Must not contain OR and NOT clauses.
// * Must not contain nested operands.
```

If we attempt the range key happy path first the issue goes away and the key condition gets correctly evaluated. I wanted to add a test case in https://github.com/fsprojects/FSharp.AWS.DynamoDB/blob/master/tests/FSharp.AWS.DynamoDB.Tests/ConditionalExpressionTests.fs either by adding a new record type or adding an inverted index to `CondExprRecord` but I wasn't able to get the tests running properly locally, running `dotnet test` runs some of the tests and then just hangs for some reason.