### PR TITLE
Add multi table transactions

### DIFF
--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -230,8 +230,10 @@ type private LimitType =
     static member AllOrCount(l: int option) = l |> Option.map Count |> Option.defaultValue All
     static member DefaultOrCount(l: int option) = l |> Option.map Count |> Option.defaultValue Default
 
-/// Helpers for building a <c>TransactWriteItemsRequest</c> to supply to <c>TransactWriteItems</c>
+/// Helpers for working with <c>TransactWriteItemsRequest</c>
 module TransactWriteItemsRequest =
+    /// <summary>Exception filter to identify whether a <c>TransactWriteItems</c> call has failed due to
+    /// one or more of the supplied <c>precondition</c> checks failing.</summary>
     let (|TransactionCanceledConditionalCheckFailed|_|): exn -> unit option =
         function
         | :? TransactionCanceledException as e when e.CancellationReasons.Exists(fun x -> x.Code = "ConditionalCheckFailed") -> Some()
@@ -530,7 +532,7 @@ type TableContext<'TRecord>
     member _.LocalSecondaryIndices = template.LocalSecondaryIndices
     /// Record-induced table template
     member _.Template = template
-    /// Transaction writer for the specified record type
+    /// Represents an individual request that can be included in the <c>TransactItems</c> of a <c>TransactWriteItems</c> call.</summary>
     member _.TransactWrite = TransactWriter<'TRecord>(tableName, template)
 
 

--- a/src/FSharp.AWS.DynamoDB/TableContext.fs
+++ b/src/FSharp.AWS.DynamoDB/TableContext.fs
@@ -2023,7 +2023,7 @@ module TransactWriteItemsRequest =
         | _ -> None
 
 
-type TransactionBuilder(?metricsCollector: (RequestMetrics -> unit)) =
+type Transaction(?metricsCollector: (RequestMetrics -> unit)) =
     let transactionItems = ResizeArray<TransactWriteItem>()
     let mutable (dynamoDbClient: IAmazonDynamoDB) = null
 
@@ -2049,7 +2049,7 @@ type TransactionBuilder(?metricsCollector: (RequestMetrics -> unit)) =
             tableContext: TableContext<'TRecord>,
             item: 'TRecord,
             ?precondition: ConditionExpression<'TRecord>
-        ) : TransactionBuilder =
+        ) : Transaction =
         setClient tableContext.Client
         let req = Put(TableName = tableContext.TableName, Item = tableContext.Template.ToAttributeValues item)
         precondition
@@ -2058,7 +2058,7 @@ type TransactionBuilder(?metricsCollector: (RequestMetrics -> unit)) =
             req.ConditionExpression <- cond.Conditional.Write writer)
         transactionItems.Add(TransactWriteItem(Put = req))
         this
-    member this.Check(tableContext: TableContext<'TRecord>, key: TableKey, condition: ConditionExpression<'TRecord>) : TransactionBuilder =
+    member this.Check(tableContext: TableContext<'TRecord>, key: TableKey, condition: ConditionExpression<'TRecord>) : Transaction =
         setClient tableContext.Client
 
         let req = ConditionCheck(TableName = tableContext.TableName, Key = tableContext.Template.ToAttributeValues key)
@@ -2073,7 +2073,7 @@ type TransactionBuilder(?metricsCollector: (RequestMetrics -> unit)) =
             updater: UpdateExpression<'TRecord>,
             ?precondition: ConditionExpression<'TRecord>
 
-        ) : TransactionBuilder =
+        ) : Transaction =
         setClient tableContext.Client
 
         let req = Update(TableName = tableContext.TableName, Key = tableContext.Template.ToAttributeValues key)
@@ -2087,7 +2087,7 @@ type TransactionBuilder(?metricsCollector: (RequestMetrics -> unit)) =
             tableContext: TableContext<'TRecord>,
             key: TableKey,
             precondition: option<ConditionExpression<'TRecord>>
-        ) : TransactionBuilder =
+        ) : Transaction =
         setClient tableContext.Client
 
         let req = Delete(TableName = tableContext.TableName, Key = tableContext.Template.ToAttributeValues key)

--- a/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
@@ -107,7 +107,7 @@ type Tests(fixture: TableFixture) =
 
         let item = mkItem (guid ()) (guid ()) 0
         do!
-            TransactionBuilder(collector.Collect)
+            Transaction(collector.Collect)
                 .Put(sut, item, compile <@ fun t -> NOT_EXISTS t.RangeKey @>)
                 .TransactWriteItems()
 
@@ -135,7 +135,7 @@ type Tests(fixture: TableFixture) =
         try
             do!
                 // The check will fail, which triggers a throw from the underlying AWS SDK; there's no way to extract the consumption info in that case
-                TransactionBuilder()
+                Transaction()
                     .Put(sut, item, compile <@ fun t -> EXISTS t.RangeKey @>)
                     .TransactWriteItems()
         with TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed ->

--- a/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
@@ -106,7 +106,7 @@ type Tests(fixture: TableFixture) =
         collector.Clear()
 
         let item = mkItem (guid ()) (guid ()) 0
-        let requests = [ TransactWrite.Put(item, Some(compile <@ fun t -> NOT_EXISTS t.RangeKey @>)) ]
+        let requests = [ sut.TransactWrite.Put(item, Some(compile <@ fun t -> NOT_EXISTS t.RangeKey @>)) ]
 
         do! sut.TransactWriteItems requests
 
@@ -132,7 +132,7 @@ type Tests(fixture: TableFixture) =
         let item = mkItem (guid ()) (guid ()) 0
 
         // The check will fail, which triggers a throw from the underlying AWS SDK; there's no way to extract the consumption info in that case
-        let requests = [ TransactWrite.Put(item, Some(compile <@ fun t -> EXISTS t.RangeKey @>)) ]
+        let requests = [ sut.TransactWrite.Put(item, Some(compile <@ fun t -> EXISTS t.RangeKey @>)) ]
 
         let mutable failed = false
         try

--- a/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/MetricsCollectorTests.fs
@@ -106,9 +106,10 @@ type Tests(fixture: TableFixture) =
         collector.Clear()
 
         let item = mkItem (guid ()) (guid ()) 0
-        let requests = [ sut.TransactWrite.Put(item, Some(compile <@ fun t -> NOT_EXISTS t.RangeKey @>)) ]
-
-        do! sut.TransactWriteItems requests
+        do!
+            TransactionBuilder(collector.Collect)
+                .Put(sut, item, compile <@ fun t -> NOT_EXISTS t.RangeKey @>)
+                .TransactWriteItems()
 
         test
             <@
@@ -130,13 +131,13 @@ type Tests(fixture: TableFixture) =
         let sut = rawTable.WithMetricsCollector(collector.Collect)
 
         let item = mkItem (guid ()) (guid ()) 0
-
-        // The check will fail, which triggers a throw from the underlying AWS SDK; there's no way to extract the consumption info in that case
-        let requests = [ sut.TransactWrite.Put(item, Some(compile <@ fun t -> EXISTS t.RangeKey @>)) ]
-
         let mutable failed = false
         try
-            do! sut.TransactWriteItems requests
+            do!
+                // The check will fail, which triggers a throw from the underlying AWS SDK; there's no way to extract the consumption info in that case
+                TransactionBuilder()
+                    .Put(sut, item, compile <@ fun t -> EXISTS t.RangeKey @>)
+                    .TransactWriteItems()
         with TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed ->
             failed <- true
         true =! failed

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -257,15 +257,15 @@ type ``TransactWriteItems tests``(table1: TableFixture, table2: TableFixture) =
     let ``All paths`` shouldFail = async {
         let item, item2, item3, item4, item5, item6, item7 = mkItem (), mkItem (), mkItem (), mkItem (), mkItem (), mkItem (), mkItem ()
         let! key = table1.PutItemAsync item
-        let Transaction = Transaction()
+        let transaction = Transaction()
 
         let requests =
-            [ Transaction.Update(table1, key, compileUpdateTable1 <@ fun t -> { t with Value = 42 } @>, existsConditionTable1)
-              Transaction.Put(table1, item2)
-              Transaction.Put(table1, item3, doesntExistConditionTable1)
-              Transaction.Delete(table1, table1.Template.ExtractKey item4, Some doesntExistConditionTable1)
-              Transaction.Delete(table1, table1.Template.ExtractKey item5, None)
-              Transaction.Check(
+            [ transaction.Update(table1, key, compileUpdateTable1 <@ fun t -> { t with Value = 42 } @>, existsConditionTable1)
+              transaction.Put(table1, item2)
+              transaction.Put(table1, item3, doesntExistConditionTable1)
+              transaction.Delete(table1, table1.Template.ExtractKey item4, Some doesntExistConditionTable1)
+              transaction.Delete(table1, table1.Template.ExtractKey item5, None)
+              transaction.Check(
                   table1,
                   table1.Template.ExtractKey item6,
                   (if shouldFail then
@@ -273,14 +273,14 @@ type ``TransactWriteItems tests``(table1: TableFixture, table2: TableFixture) =
                    else
                        doesntExistConditionTable1)
               )
-              Transaction.Update(
+              transaction.Update(
                   table1,
                   TableKey.Combined(item7.HashKey, item7.RangeKey),
                   compileUpdateTable1 <@ fun t -> { t with Tuple = (42, 42) } @>
               ) ]
         let mutable failed = false
         try
-            do! Transaction.TransactWriteItems()
+            do! transaction.TransactWriteItems()
         with TransactWriteItemsRequest.TransactionCanceledConditionalCheckFailed ->
             failed <- true
         failed =! shouldFail


### PR DESCRIPTION
## What?
Changes the transaction API to allow multi table transactions

## How?
Instead of letting `TransactWrite` accept items with a specific record type I added a `TransactWrite` member to the table context.

This `TransactWrite` member has the `Put/Update/Delete/Check`oprerations and replaces operations on the `TransactWrite` module that previously existed.