### PR TITLE
Fix handling of key attributes with CustomName attributes

### DIFF
--- a/src/FSharp.AWS.DynamoDB/Picklers/RecordPickler.fs
+++ b/src/FSharp.AWS.DynamoDB/Picklers/RecordPickler.fs
@@ -26,8 +26,10 @@ type RecordPickler<'T>(ctor: obj[] -> obj, properties: PropertyMetadata[]) =
             let field = prop.PropertyInfo.GetValue value
             match prop.Pickler.PickleUntyped field with
             | None -> ()
-            | Some av -> values.Add(prop.Name, av)
-
+            | Some av ->
+                let exists, value = values.TryGetValue prop.Name
+                if not exists then
+                    values.Add(prop.Name, av)
         values
 
     member __.ToRecord(ro: RestObject) : 'T =


### PR DESCRIPTION
## What?
Fixes an issue where you have an inverted key for a GSI and you are using the CustomName attribute at the same time