### PR TITLE
Allow empty strings

### DIFF
--- a/src/FSharp.AWS.DynamoDB/Picklers/PrimitivePicklers.fs
+++ b/src/FSharp.AWS.DynamoDB/Picklers/PrimitivePicklers.fs
@@ -36,8 +36,6 @@ type StringPickler() =
     override _.Pickle s =
         if isNull s then
             AttributeValue(NULL = true)
-        elif s = "" then
-            invalidOp "empty strings not supported by DynamoDB."
         else
             AttributeValue(s)
         |> Some

--- a/tests/FSharp.AWS.DynamoDB.Tests/RecordGenerationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/RecordGenerationTests.fs
@@ -30,10 +30,8 @@ module ``Record Generation Tests`` =
                         test <@ r' = r @>
                 with
                 // account for random inputs not supported by the library
-                | :? InvalidOperationException as e when e.Message = "empty strings not supported by DynamoDB." -> ()
                 | :? ArgumentException as e when
-                    e.Message.Contains "unsupported key name" && e.Message.Contains "should be 1 to 64k long (as utf8)"
-                    ->
+                    e.Message.Contains "unsupported key name" && e.Message.Contains "should be 1 to 64k long (as utf8)" ->
                     ()
 
             Check.One(config, roundTrip)

--- a/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/SimpleTableOperationTests.fs
@@ -18,6 +18,8 @@ module SimpleTableTypes =
           [<RangeKey>]
           RangeKey: string
 
+          EmptyString: string
+
           Value: int64
 
           Tuple: int64 * int64
@@ -46,6 +48,7 @@ type ``Simple Table Operation Tests``(fixture: TableFixture) =
     let mkItem () =
         { HashKey = guid ()
           RangeKey = guid ()
+          EmptyString = ""
           Value = rand ()
           Tuple = rand (), rand ()
           Map = seq { for _ in 0L .. rand () % 5L -> "K" + guid (), rand () } |> Map.ofSeq
@@ -139,6 +142,7 @@ type ``TransactWriteItems tests``(fixture: TableFixture) =
     let mkItem () =
         { HashKey = guid ()
           RangeKey = guid ()
+          EmptyString = ""
           Value = rand ()
           Tuple = rand (), rand ()
           Map = seq { for _ in 0L .. rand () % 5L -> "K" + guid (), rand () } |> Map.ofSeq


### PR DESCRIPTION
## What?
DynamoDB has supported empty strings for non-key attributes since mid 2020: https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-dynamodb-now-supports-empty-values-for-non-key-string-and-binary-attributes-in-dynamodb-tables/