### PR TITLE
Fixes bugs in Print with AWS SDK v4

### DIFF
--- a/src/FSharp.AWS.DynamoDB/Utils/DynamoUtils.fs
+++ b/src/FSharp.AWS.DynamoDB/Utils/DynamoUtils.fs
@@ -108,10 +108,10 @@ let inline unwrap (avw: AttributeValueEqWrapper) = avw.AttributeValue
 
 type AttributeValue with
 
-    member inline x.IsNULL = x.NULL.GetValueOrDefault false 
-    member inline av.IsSSSet = av.SS.Count > 0
-    member inline av.IsNSSet = av.NS.Count > 0
-    member inline av.IsBSSet = av.BS.Count > 0
+    member inline x.IsNULL = x.NULL.GetValueOrDefault false
+    member inline av.IsSSSet = notNull av.SS
+    member inline av.IsNSSet = notNull av.NS
+    member inline av.IsBSSet = notNull av.BS
 
     member av.Print() =
         if av.IsNULL then
@@ -123,12 +123,12 @@ type AttributeValue with
         elif av.N <> null then
             sprintf "{ N = %s }" av.N
         elif av.B <> null then
-            sprintf "{ N = %A }" (av.B.ToArray())
-        elif av.SS.Count > 0 then
+            sprintf "{ B = %A }" (av.B.ToArray())
+        elif notNull av.SS then
             sprintf "{ SS = %A }" (Seq.toArray av.SS)
-        elif av.NS.Count > 0 then
-            sprintf "{ SN = %A }" (Seq.toArray av.NS)
-        elif av.BS.Count > 0 then
+        elif notNull av.NS then
+            sprintf "{ NS = %A }" (Seq.toArray av.NS)
+        elif notNull av.BS then
             av.BS |> Seq.map _.ToArray() |> Seq.toArray |> sprintf "{ BS = %A }"
         elif av.IsLSet then
             av.L |> Seq.map _.Print() |> Seq.toArray |> sprintf "{ L = %A }"

--- a/src/FSharp.AWS.DynamoDB/Utils/DynamoUtils.fs
+++ b/src/FSharp.AWS.DynamoDB/Utils/DynamoUtils.fs
@@ -109,9 +109,6 @@ let inline unwrap (avw: AttributeValueEqWrapper) = avw.AttributeValue
 type AttributeValue with
 
     member inline x.IsNULL = x.NULL.GetValueOrDefault false
-    member inline av.IsSSSet = notNull av.SS
-    member inline av.IsNSSet = notNull av.NS
-    member inline av.IsBSSet = notNull av.BS
 
     member av.Print() =
         if av.IsNULL then
@@ -124,16 +121,16 @@ type AttributeValue with
             sprintf "{ N = %s }" av.N
         elif av.B <> null then
             sprintf "{ B = %A }" (av.B.ToArray())
-        elif notNull av.SS then
+        elif av.IsSSSet then
             sprintf "{ SS = %A }" (Seq.toArray av.SS)
-        elif notNull av.NS then
+        elif av.IsNSSet then
             sprintf "{ NS = %A }" (Seq.toArray av.NS)
-        elif notNull av.BS then
+        elif av.IsBSSet then
             av.BS |> Seq.map _.ToArray() |> Seq.toArray |> sprintf "{ BS = %A }"
         elif av.IsLSet then
             av.L |> Seq.map _.Print() |> Seq.toArray |> sprintf "{ L = %A }"
         elif av.IsMSet then
-            av.M |> Seq.map (fun kv -> (kv.Key, kv.Value.Print())) |> Seq.toArray |> sprintf "{ M = %A }"
+            av.M |> Seq.map (fun kv -> kv.Key, kv.Value.Print()) |> Seq.toArray |> sprintf "{ M = %A }"
         else
             "{ }"
 

--- a/tests/FSharp.AWS.DynamoDB.Tests/DynamoUtilsTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/DynamoUtilsTests.fs
@@ -13,6 +13,13 @@ open Amazon.DynamoDBv2.Model
 type ``DynamoUtils Tests``() =
 
     [<Fact>]
+    let ``AttributeValue.Print() works for NULL`` () =
+        let attributeValue = AttributeValue(NULL = true)
+        let expected = "{ NULL = true }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
     let ``AttributeValue.Print() works for S`` () =
         let attributeValue = AttributeValue(S = "abc")
         let expected = "{ S = abc }"
@@ -29,7 +36,7 @@ type ``DynamoUtils Tests``() =
     [<Fact>]
     let ``AttributeValue.Print() works for B`` () =
         let attributeValue = AttributeValue(B = new MemoryStream([| 1uy; 2uy; 3uy |]))
-        let expected = "{ B = [|1; 2; 3|] }"
+        let expected = "{ B = [|1uy; 2uy; 3uy|] }"
 
         test <@ attributeValue.Print() = expected @>
 
@@ -37,6 +44,13 @@ type ``DynamoUtils Tests``() =
     let ``AttributeValue.Print() works for SS`` () =
         let attributeValue = AttributeValue(SS = ResizeArray [ "a"; "b"; "c" ])
         let expected = "{ SS = [|\"a\"; \"b\"; \"c\"|] }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for SS singleton`` () =
+        let attributeValue = AttributeValue(SS = ResizeArray [ "abc" ])
+        let expected = "{ SS = [|\"abc\"|] }"
 
         test <@ attributeValue.Print() = expected @>
 
@@ -51,14 +65,14 @@ type ``DynamoUtils Tests``() =
     let ``AttributeValue.Print() works for BS`` () =
         let attributeValue =
             AttributeValue(BS = ResizeArray [ new MemoryStream([| 1uy; 2uy; 3uy |]); new MemoryStream([| 4uy; 5uy; 6uy |]) ])
-        let expected = "{ BS = [|[|1; 2; 3|]; [|4; 5; 6|]|] }"
+        let expected = "{ BS = [|[|1uy; 2uy; 3uy|]; [|4uy; 5uy; 6uy|]|] }"
 
         test <@ attributeValue.Print() = expected @>
 
     [<Fact>]
     let ``AttributeValue.Print() works for L`` () =
         let attributeValue = AttributeValue(L = ResizeArray [ AttributeValue(S = "a"); AttributeValue(S = "b"); AttributeValue(S = "c") ])
-        let expected = "{ L = [|{ S = a }; { S = b }; { S = c }|] }"
+        let expected = "{ L = [|\"{ S = a }\"; \"{ S = b }\"; \"{ S = c }\"|] }"
 
         test <@ attributeValue.Print() = expected @>
 
@@ -73,6 +87,6 @@ type ``DynamoUtils Tests``() =
                     )
             )
 
-        let expected = "{ M = [|(\"a\", { S = 1 }); (\"b\", { S = 2 }); (\"c\", { S = 3 })|] }"
+        let expected = "{ M = [|(\"a\", \"{ S = 1 }\"); (\"b\", \"{ S = 2 }\"); (\"c\", \"{ S = 3 }\")|] }"
 
         test <@ attributeValue.Print() = expected @>

--- a/tests/FSharp.AWS.DynamoDB.Tests/DynamoUtilsTests.fs
+++ b/tests/FSharp.AWS.DynamoDB.Tests/DynamoUtilsTests.fs
@@ -1,0 +1,78 @@
+namespace FSharp.AWS.DynamoDB.Tests
+
+open System.Collections.Generic
+open System.IO
+
+open Swensen.Unquote
+open Xunit
+
+open FSharp.AWS.DynamoDB
+
+open Amazon.DynamoDBv2.Model
+
+type ``DynamoUtils Tests``() =
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for S`` () =
+        let attributeValue = AttributeValue(S = "abc")
+        let expected = "{ S = abc }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for N`` () =
+        let attributeValue = AttributeValue(N = "123")
+        let expected = "{ N = 123 }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for B`` () =
+        let attributeValue = AttributeValue(B = new MemoryStream([| 1uy; 2uy; 3uy |]))
+        let expected = "{ B = [|1; 2; 3|] }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for SS`` () =
+        let attributeValue = AttributeValue(SS = ResizeArray [ "a"; "b"; "c" ])
+        let expected = "{ SS = [|\"a\"; \"b\"; \"c\"|] }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for NS`` () =
+        let attributeValue = AttributeValue(NS = ResizeArray [ "1"; "2"; "3" ])
+        let expected = "{ NS = [|\"1\"; \"2\"; \"3\"|] }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for BS`` () =
+        let attributeValue =
+            AttributeValue(BS = ResizeArray [ new MemoryStream([| 1uy; 2uy; 3uy |]); new MemoryStream([| 4uy; 5uy; 6uy |]) ])
+        let expected = "{ BS = [|[|1; 2; 3|]; [|4; 5; 6|]|] }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for L`` () =
+        let attributeValue = AttributeValue(L = ResizeArray [ AttributeValue(S = "a"); AttributeValue(S = "b"); AttributeValue(S = "c") ])
+        let expected = "{ L = [|{ S = a }; { S = b }; { S = c }|] }"
+
+        test <@ attributeValue.Print() = expected @>
+
+    [<Fact>]
+    let ``AttributeValue.Print() works for M`` () =
+        let attributeValue =
+            AttributeValue(
+                M =
+                    Dictionary<string, AttributeValue>(
+                        [ "a", AttributeValue(S = "1"); "b", AttributeValue(S = "2"); "c", AttributeValue(S = "3") ]
+                        |> Seq.map (fun (k, v) -> KeyValuePair(k, v))
+                    )
+            )
+
+        let expected = "{ M = [|(\"a\", { S = 1 }); (\"b\", { S = 2 }); (\"c\", { S = 3 })|] }"
+
+        test <@ attributeValue.Print() = expected @>

--- a/tests/FSharp.AWS.DynamoDB.Tests/FSharp.AWS.DynamoDB.Tests.fsproj
+++ b/tests/FSharp.AWS.DynamoDB.Tests/FSharp.AWS.DynamoDB.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>  
+  </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />
     <Compile Include="Utils.fs" />
@@ -14,6 +14,7 @@
     <Compile Include="SparseGSITests.fs" />
     <Compile Include="PaginationTests.fs" />
     <Compile Include="MetricsCollectorTests.fs" />
+    <Compile Include="DynamoUtilsTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FSharp.AWS.DynamoDB\FSharp.AWS.DynamoDB.fsproj" />


### PR DESCRIPTION
This PR fixes some bugs in `AttributeValue.Print` that were introduced by the upgrade to AWS SDK v4.
Also fixed is a bug where `NS` was printing as `SN`. 
Test coverage is improved.